### PR TITLE
ensure file object consistency in firefox

### DIFF
--- a/src/upload.js
+++ b/src/upload.js
@@ -4,7 +4,7 @@ import parse from "url-parse";
 export async function upload(portalUrl, file, options = {}) {
   const formData = new FormData();
 
-  formData.append("file", file);
+  formData.append("file", ensureFileObjectConsistency(file));
 
   const parsed = parse(portalUrl);
 
@@ -29,7 +29,7 @@ export async function uploadDirectory(portalUrl, directory, filename, options = 
   const formData = new FormData();
 
   Object.entries(directory).forEach(([path, file]) => {
-    formData.append("files[]", file, path);
+    formData.append("files[]", ensureFileObjectConsistency(file), path);
   });
 
   const parsed = parse(portalUrl);
@@ -50,4 +50,15 @@ export async function uploadDirectory(portalUrl, directory, filename, options = 
   );
 
   return data;
+}
+
+/**
+ * Sometimes file object might have had the type property defined menually with Object.defineProperty
+ * and some browsers (namely firefox) can have problems reading it after the file has been appended
+ * to form data. To overcome this, we recreate the file object using native File constructor with
+ * a type defined as a constructor argument.
+ * Related issue: https://github.com/NebulousLabs/skynet-webportal/issues/290
+ */
+export function ensureFileObjectConsistency(file) {
+  return new File([file], file.name, { type: file.type });
 }

--- a/src/upload.js
+++ b/src/upload.js
@@ -53,12 +53,12 @@ export async function uploadDirectory(portalUrl, directory, filename, options = 
 }
 
 /**
- * Sometimes file object might have had the type property defined menually with Object.defineProperty
+ * Sometimes file object might have had the type property defined manually with Object.defineProperty
  * and some browsers (namely firefox) can have problems reading it after the file has been appended
  * to form data. To overcome this, we recreate the file object using native File constructor with
  * a type defined as a constructor argument.
  * Related issue: https://github.com/NebulousLabs/skynet-webportal/issues/290
  */
-export function ensureFileObjectConsistency(file) {
+function ensureFileObjectConsistency(file) {
   return new File([file], file.name, { type: file.type });
 }


### PR DESCRIPTION
Sometimes file object might have had the type property defined menually with Object.defineProperty and some browsers (namely firefox) can have problems reading it after the file has been appended to form data. To overcome this, we recreate the file object using native File constructor with a type defined as a constructor argument.

Closes https://github.com/NebulousLabs/skynet-webportal/issues/290