### PR TITLE
Rollback UploadFile Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.7]
+
+### Changed
+
+- Revert: "Fixed a bug causing `uploadFile` to not work." introduced in 2.04
+
 ## [2.0.6]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Revert: "Fixed a bug causing `uploadFile` to not work." introduced in 2.04
+- Revert: "Fixed a bug causing `uploadFile` to not work." introduced in 2.0.4
 
 ## [2.0.6]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skynet-js",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Sia Skynet Javascript Client",
   "main": "dist/index.js",
   "files": [

--- a/src/upload.js
+++ b/src/upload.js
@@ -18,8 +18,8 @@ SkynetClient.prototype.uploadFileRequest = async function (file, customOptions =
 
   const formData = new FormData();
   file = ensureFileObjectConsistency(file);
-  const options = opts.customFilename ? { filename: opts.customFilename } : {};
-  formData.append(opts.portalFileFieldname, file, options);
+  const filename = opts.customFilename ? opts.customFilename : "";
+  formData.append(opts.portalFileFieldname, file, filename);
 
   const { data } = await this.executeRequest({
     ...opts,


### PR DESCRIPTION
This MR rolls back a bugfix introduced in 2.0.4 in `uploadFile` and bumps the version to 2.0.7. Unfortunately we know very little on why it was added in the first place,  but passing an object to the formdata yields [Object ojbect]` as the filename.