### PR TITLE
fix default portal location issue on localhost

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ export function defaultOptions(endpointPath) {
 export function defaultPortalUrl() {
   if (typeof window === "undefined") return "/"; // default to path root on ssr
   const url = new URL(window.location.href);
-  return url.href.substring(0, url.href.indexOf(url.pathname));
+  return url.origin;
 }
 
 function getFilePath(file) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,8 +27,7 @@ export function defaultOptions(endpointPath) {
 // https://github.com/NebulousLabs/skynet-docs/issues/21.
 export function defaultPortalUrl() {
   if (typeof window === "undefined") return "/"; // default to path root on ssr
-  const url = new URL(window.location.href);
-  return url.origin;
+  return window.location.origin;
 }
 
 function getFilePath(file) {


### PR DESCRIPTION
Replaced `url.href.substring(0, url.href.indexOf(url.pathname))` with `window.location.origin`.

For http://localhost:8000 it used to return `http:` and fixed version returns correctly `http://localhost:8000`.