### PR TITLE
do not use location when parsing a skylink in browser

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -79,7 +79,9 @@ export function parseSkylink(skylink) {
 
   // check for skylink passed in an url and extract it
   // example: https://siasky.net/XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg
-  const parsed = parse(skylink);
+
+  // pass empty object as second param to disable using location as base url when parsing in browser
+  const parsed = parse(skylink, {});
   const matchPathname = parsed.pathname.match(SKYLINK_PATHNAME_REGEX);
   if (matchPathname) return matchPathname[SKYLINK_REGEXP_MATCH_POSITION];
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,7 +62,7 @@ export function makeUrl(...args) {
 
 const SKYLINK_MATCHER = "([a-zA-Z0-9_-]{46})";
 const SKYLINK_DIRECT_REGEX = new RegExp(`^${SKYLINK_MATCHER}$`);
-const SKYLINK_PATHNAME_REGEX = new RegExp(`^/${SKYLINK_MATCHER}`);
+const SKYLINK_PATHNAME_REGEX = new RegExp(`^/?${SKYLINK_MATCHER}`);
 const SKYLINK_REGEXP_MATCH_POSITION = 1;
 
 export function parseSkylink(skylink) {


### PR DESCRIPTION
Fixes an issue where when trying to parse a skylink url, it uses location in browser as base url. This is problematic if we're running that on skynet uploaded web app because it will pick the app's url as base url and include app's skylink.

Documentation: https://github.com/unshiftio/url-parse

> Note that when url-parse is used in a browser environment, it will default to using the browser's current window location as the base URL when parsing all inputs. To parse an input independently of the browser's current URL (e.g. for functionality parity with the library in a Node environment), pass an empty location object as the second parameter:

```javascript
var parse = require('url-parse');
parse('hostname', {});
```

closes #96 