### PR TITLE
Run unit tests on node 14 and 15

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
- added node 14 and 15 to github unit test runner matrix
- removed node 13 since it's not really active release any more according to https://nodejs.org/en/about/releases/