### PR TITLE
use buffer wrapper before hex transformation

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -46,7 +46,7 @@ export async function getEntry(
       ...opts,
       method: "get",
       query: {
-        publickey: `ed25519:${publicKey.toString("hex")}`,
+        publickey: `ed25519:${Buffer.from(publicKey).toString("hex")}`,
         datakey: Buffer.from(HashDataKey(datakey)).toString("hex"),
       },
       timeout: opts.timeout,


### PR DESCRIPTION
- native `Uint8Array` doesn't support `toString("hex")` method, it needs to be called on `Buffer` instance
- unit tests passed because in nodejs `publicKey` is a `Buffer` instance