### PR TITLE
Bigint revision

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -78,7 +78,7 @@ export class SkynetClient {
    * Creates and executes a request.
    * @param {Object} config - Configuration for the request. See docs for constructor for the full list of options.
    */
-  executeRequest(config: any): Promise<AxiosResponse> {
+  protected executeRequest(config: any): Promise<AxiosResponse> {
     if (config.skykeyName || config.skykeyId) {
       throw new Error("Unimplemented: skykeys have not been implemented in this SDK");
     }
@@ -91,7 +91,10 @@ export class SkynetClient {
       url = addUrlQuery(url, config.query);
     }
 
-    const headers = { ...config.headers, "User-Agent": config.customUserAgent && config.customUserAgent };
+    const headers = { ...config.headers };
+    if (config.customUserAgent) {
+      headers["User-Agent"] = config.customUserAgent;
+    }
 
     return axios({
       url,

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,8 +91,8 @@ export class SkynetClient {
       url = addUrlQuery(url, config.query);
     }
 
-    // No other headers.
-    const headers = config.customUserAgent && { "User-Agent": config.customUserAgent };
+    let headers = config.customUserAgent && { "User-Agent": config.customUserAgent };
+    headers = { ...config.headers, ...headers };
 
     return axios({
       url,
@@ -108,6 +108,8 @@ export class SkynetClient {
           config.onUploadProgress(progress, event);
         },
       timeout: config.timeout,
+      transformRequest: config.transformRequest,
+      transformResponse: config.transformResponse,
 
       maxContentLength: Infinity,
       maxBodyLength: Infinity,

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,8 +91,7 @@ export class SkynetClient {
       url = addUrlQuery(url, config.query);
     }
 
-    let headers = config.customUserAgent && { "User-Agent": config.customUserAgent };
-    headers = { ...config.headers, ...headers };
+    const headers = { ...config.headers, "User-Agent": config.customUserAgent && config.customUserAgent };
 
     return axios({
       url,

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -43,7 +43,7 @@ describe("hashRegistryValue", () => {
     const hash = hashRegistryEntry({
       datakey: "HelloWorld",
       data: "abc",
-      revision: 123456789,
+      revision: BigInt(123456789),
     });
 
     expect(toHexString(hash)).toEqual(h);

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -1,5 +1,5 @@
 import { deriveChildSeed, encodeBigintAsUint64, genKeyPairFromSeed, hashRegistryEntry } from "./crypto";
-import { maxint, toHexString } from "./utils";
+import { MAX_REVISION, toHexString } from "./utils";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -59,10 +59,10 @@ describe("encodeBigint", () => {
     expect(encodeBigintAsUint64(BigInt(255))).toEqualUint8Array(new Uint8Array([255, 0, 0, 0, 0, 0, 0, 0]));
     expect(encodeBigintAsUint64(BigInt(256))).toEqualUint8Array(new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0]));
     expect(encodeBigintAsUint64(BigInt(256))).not.toEqualUint8Array(new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0]));
-    expect(encodeBigintAsUint64(BigInt(maxint))).toEqualUint8Array(
+    expect(encodeBigintAsUint64(MAX_REVISION)).toEqualUint8Array(
       new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255])
     );
-    expect(() => encodeBigintAsUint64(BigInt(maxint) + BigInt(1))).toThrowError(
+    expect(() => encodeBigintAsUint64(MAX_REVISION + BigInt(1))).toThrowError(
       "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"
     );
   });

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -64,7 +64,9 @@ describe("encodeBigint", () => {
     expect(encodeBigintAsUint64(BigInt(maxint))).toEqualUint8Array(
       new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255])
     );
-    expect(() => encodeBigintAsUint64(BigInt(maxint) + BigInt(1))).toThrowError("Received int > 2^64-1");
+    expect(() => encodeBigintAsUint64(BigInt(maxint) + BigInt(1))).toThrowError(
+      "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"
+    );
   });
 });
 

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -1,5 +1,5 @@
 import { deriveChildSeed, encodeBigintAsUint64, genKeyPairFromSeed, hashRegistryEntry } from "./crypto";
-import { toHexString } from "./utils";
+import { maxint, toHexString } from "./utils";
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -55,8 +55,6 @@ describe("deriveChildSeed", () => {
 
 describe("encodeBigint", () => {
   it("should correctly encode bigints", () => {
-    const maxint = "18446744073709551615";
-
     expect(encodeBigintAsUint64(BigInt(0))).toEqualUint8Array(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]));
     expect(encodeBigintAsUint64(BigInt(255))).toEqualUint8Array(new Uint8Array([255, 0, 0, 0, 0, 0, 0, 0]));
     expect(encodeBigintAsUint64(BigInt(256))).toEqualUint8Array(new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0]));

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -1,5 +1,14 @@
-import { deriveChildSeed, genKeyPairFromSeed, hashRegistryEntry } from "./crypto";
-import { toHexString } from "./utils";
+import { deriveChildSeed, encodeBigintAsUint64, genKeyPairFromSeed, hashRegistryEntry } from "./crypto";
+import { areEqualUint8Arrays, toHexString } from "./utils";
+
+describe("areEqualUint8Arrays", () => {
+  it("should correctly check whether uint8arrays are equal", () => {
+    expect(areEqualUint8Arrays(new Uint8Array([0]), new Uint8Array([0]))).toBeTruthy();
+    expect(areEqualUint8Arrays(new Uint8Array([1, 1, 0]), new Uint8Array([1, 1, 0]))).toBeTruthy();
+    expect(areEqualUint8Arrays(new Uint8Array([1, 0, 0]), new Uint8Array([1, 1, 0]))).toBeFalsy();
+    expect(areEqualUint8Arrays(new Uint8Array([1, 1, 0]), new Uint8Array([1, 1, 0, 0]))).toBeFalsy();
+  });
+});
 
 describe("deriveChildSeed", () => {
   it("should correctly derive a child seed", () => {
@@ -17,6 +26,30 @@ describe("deriveChildSeed", () => {
     const seed3 = deriveChildSeed(masterSeed, "ds");
     expect(seed1).not.toEqual(seed2);
     expect(seed2).not.toEqual(seed3);
+  });
+});
+
+describe("encodeBigint", () => {
+  it("should correctly encode bigints", () => {
+    const maxint = "18446744073709551615";
+
+    expect(areEqualUint8Arrays(encodeBigintAsUint64(BigInt(0)), new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]))).toBeTruthy();
+    expect(
+      areEqualUint8Arrays(encodeBigintAsUint64(BigInt(255)), new Uint8Array([255, 0, 0, 0, 0, 0, 0, 0]))
+    ).toBeTruthy();
+    expect(
+      areEqualUint8Arrays(encodeBigintAsUint64(BigInt(256)), new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0]))
+    ).toBeTruthy();
+    expect(
+      areEqualUint8Arrays(encodeBigintAsUint64(BigInt(256)), new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0]))
+    ).toBeFalsy();
+    expect(
+      areEqualUint8Arrays(
+        encodeBigintAsUint64(BigInt(maxint)),
+        new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255])
+      )
+    ).toBeTruthy();
+    expect(() => encodeBigintAsUint64(BigInt(maxint) + BigInt(1))).toThrowError("Received int > 2^64-1");
   });
 });
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -32,7 +32,7 @@ export function hashRegistryEntry(registryEntry: RegistryEntry): Uint8Array {
   return hashAll(
     hashDataKey(registryEntry.datakey),
     encodeString(registryEntry.data),
-    encodeNumber(registryEntry.revision)
+    encodeBigInt(registryEntry.revision)
   );
 }
 
@@ -43,6 +43,22 @@ function encodeNumber(num: number): Uint8Array {
     const byte = num & 0xff;
     encoded[index] = byte;
     num = num >> 8;
+  }
+  return encoded;
+}
+
+/**
+ * Converts the given bigint into a uint8 array.
+ *
+ * @param int - Bigint to encode.
+ * @returns - Bigint encoded as a byte array.
+ */
+function encodeBigInt(int: bigint): Uint8Array {
+  const encoded = new Uint8Array(8);
+  for (let index = 0; index < encoded.length; index++) {
+    const byte = int & BigInt(0xff);
+    encoded[index] = Number(byte);
+    int = int >> BigInt(8);
   }
   return encoded;
 }

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,7 +1,7 @@
 import { pki, pkcs5, md } from "node-forge";
 import blake from "blakejs";
 import { RegistryEntry } from "./registry";
-import { stringToUint8Array, toHexString } from "./utils";
+import { checkUint64, stringToUint8Array, toHexString } from "./utils";
 import randomBytes from "randombytes";
 
 export type PublicKey = pki.ed25519.NativeBuffer;
@@ -55,10 +55,7 @@ function encodeNumber(num: number): Uint8Array {
  */
 export function encodeBigintAsUint64(int: bigint): Uint8Array {
   // Assert the input is 64 bits.
-  const newint = BigInt.asUintN(64, int);
-  if (newint != int) {
-    throw new Error("Received int > 2^64-1");
-  }
+  checkUint64(int);
 
   const encoded = new Uint8Array(8);
   for (let index = 0; index < encoded.length; index++) {

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -32,7 +32,7 @@ export function hashRegistryEntry(registryEntry: RegistryEntry): Uint8Array {
   return hashAll(
     hashDataKey(registryEntry.datakey),
     encodeString(registryEntry.data),
-    encodeBigInt(registryEntry.revision)
+    encodeBigintAsUint64(registryEntry.revision)
   );
 }
 
@@ -53,7 +53,13 @@ function encodeNumber(num: number): Uint8Array {
  * @param int - Bigint to encode.
  * @returns - Bigint encoded as a byte array.
  */
-function encodeBigInt(int: bigint): Uint8Array {
+export function encodeBigintAsUint64(int: bigint): Uint8Array {
+  // Assert the input is 64 bits.
+  const newint = BigInt.asUintN(64, int);
+  if (newint != int) {
+    throw new Error("Received int > 2^64-1");
+  }
+
   const encoded = new Uint8Array(8);
   for (let index = 0; index < encoded.length; index++) {
     const byte = int & BigInt(0xff);

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -52,6 +52,7 @@ function encodeNumber(num: number): Uint8Array {
  *
  * @param int - Bigint to encode.
  * @returns - Bigint encoded as a byte array.
+ * @throws - Will throw if the int does not fit in 64 bits.
  */
 export function encodeBigintAsUint64(int: bigint): Uint8Array {
   // Assert the input is 64 bits.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type { PublicKey, SecretKey, Signature } from "./crypto";
 export type { SignedRegistryEntry, RegistryEntry } from "./registry";
 
 export {
+  MAX_REVISION,
   defaultPortalUrl,
   defaultSkynetPortalUrl,
   getRelativeFilePath,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,38 +1,41 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
 
 const { publicKey, privateKey } = genKeyPairAndSeed();
-const client = new SkynetClient("https://siasky.dev");
+const client = new SkynetClient("https://siasky.net");
 
 const dataKey = "HelloWorld";
+const maxint = BigInt("18446744073709551615"); // max uint64
 
 // skip - used to verify end-to-end flow
-describe.skip("siasky.dev end to end integration test", () => {
-  it("should be able to both setJSON and getJSON", async () => {
-    // Set and get a new entry (revision should be 0).
+describe("siasky.dev end to end integration test", () => {
+  // NOTE: These tests must run sequentially.
+  // https://jestjs.io/docs/en/setup-teardown.html#order-of-execution-of-describe-and-test-blocks
 
-    let json = { data: "thisistext" };
+  test("Should set and get new entries", async () => {
+    const json = { data: "thisistext" };
 
     // Set the file in the SkyDB.
     await client.db.setJSON(privateKey, dataKey, json);
 
     // get the file in the SkyDB
-    let actual = await client.db.getJSON(publicKey, dataKey);
+    const actual = await client.db.getJSON(publicKey, dataKey);
     expect(actual.data).toEqual(json);
+    // Revision should be 0.
     expect(actual.revision).toEqual(BigInt(0));
+  });
 
-    // Set the revision to the max allowed.
-
-    const maxint = BigInt("18446744073709551615"); // max uint64
-    json = { data: "testnumber2" };
+  test("Should set and get entries with the revision at the max allowed", async () => {
+    const json = { data: "testnumber2" };
 
     await client.db.setJSON(privateKey, dataKey, json, maxint);
 
-    actual = await client.db.getJSON(publicKey, dataKey);
+    const actual = await client.db.getJSON(publicKey, dataKey);
     expect(actual.data).toEqual(json);
     expect(actual.revision).toEqual(maxint);
+  });
 
-    // Try setting the revision higher than the uint64 max.
-
+  test("Try setting the revision higher than the uint64 max", async () => {
+    const json = { data: "testnumber3" };
     const largeint = maxint + BigInt(1);
 
     await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrow();

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,13 +1,13 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
 
 const { publicKey, privateKey } = genKeyPairAndSeed();
-const client = new SkynetClient("https://siasky.dev");
+const client = new SkynetClient("https://siasky.net");
 
 const datakey = "HelloWorld";
 const json = { data: "thisistext" };
 
 // skip - used to verify end-to-end flow
-describe.skip("siasky.dev end to end integration test", () => {
+describe("siasky.dev end to end integration test", () => {
   it("should be able to both setJSON and getJSON", async () => {
     // set the file in the SkyDB
     await client.db.setJSON(privateKey, datakey, json);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,9 +1,9 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
+import { maxint } from "./utils";
 
 const client = new SkynetClient("https://siasky.dev");
 
 const dataKey = "HelloWorld";
-const maxint = BigInt("18446744073709551615"); // max uint64
 
 // skip - used to verify end-to-end flow
 describe.skip("siasky.dev end to end integration test", () => {

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,12 +1,13 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
-import { maxint } from "./utils";
+import { MAX_REVISION } from "./utils";
 
-const client = new SkynetClient("https://siasky.dev");
+// TODO: Use siasky.dev when available.
+const client = new SkynetClient("https://siasky.net");
 
 const dataKey = "HelloWorld";
 
-// skip - used to verify end-to-end flow
-describe.skip("siasky.dev end to end integration test", () => {
+// Used to verify end-to-end flow.
+describe("siasky.dev end to end integration test", () => {
   it("Should set and get new entries", async () => {
     const { publicKey, privateKey } = genKeyPairAndSeed();
     const json = { data: "thisistext" };
@@ -25,17 +26,17 @@ describe.skip("siasky.dev end to end integration test", () => {
     const { publicKey, privateKey } = genKeyPairAndSeed();
     const json = { data: "testnumber2" };
 
-    await client.db.setJSON(privateKey, dataKey, json, maxint);
+    await client.db.setJSON(privateKey, dataKey, json, MAX_REVISION);
 
     const actual = await client.db.getJSON(publicKey, dataKey);
     expect(actual.data).toEqual(json);
-    expect(actual.revision).toEqual(maxint);
+    expect(actual.revision).toEqual(MAX_REVISION);
   });
 
   it("Try setting the revision higher than the uint64 max", async () => {
     const { privateKey } = genKeyPairAndSeed();
     const json = { data: "testnumber3" };
-    const largeint = maxint + BigInt(1);
+    const largeint = MAX_REVISION + BigInt(1);
 
     await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrowError(
       "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -3,7 +3,7 @@ import { genKeyPairAndSeed, SkynetClient } from "./index";
 const { publicKey, privateKey } = genKeyPairAndSeed();
 const client = new SkynetClient("https://siasky.dev");
 
-const datakey = "HelloWorld";
+const dataKey = "HelloWorld";
 
 // skip - used to verify end-to-end flow
 describe.skip("siasky.dev end to end integration test", () => {
@@ -13,10 +13,10 @@ describe.skip("siasky.dev end to end integration test", () => {
     let json = { data: "thisistext" };
 
     // Set the file in the SkyDB.
-    await client.db.setJSON(privateKey, datakey, json);
+    await client.db.setJSON(privateKey, dataKey, json);
 
     // get the file in the SkyDB
-    let actual = await client.db.getJSON(publicKey, datakey);
+    let actual = await client.db.getJSON(publicKey, dataKey);
     expect(actual.data).toEqual(json);
     expect(actual.revision).toEqual(BigInt(0));
 
@@ -25,10 +25,16 @@ describe.skip("siasky.dev end to end integration test", () => {
     const maxint = BigInt("18446744073709551615"); // max uint64
     json = { data: "testnumber2" };
 
-    await client.db.setJSON(privateKey, datakey, json, maxint);
+    await client.db.setJSON(privateKey, dataKey, json, maxint);
 
-    actual = await client.db.getJSON(publicKey, datakey);
+    actual = await client.db.getJSON(publicKey, dataKey);
     expect(actual.data).toEqual(json);
     expect(actual.revision).toEqual(maxint);
+
+    // Try setting the revision higher than the uint64 max.
+
+    const largeint = maxint + BigInt(1);
+
+    await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrow();
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,13 +1,13 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
 
 const { publicKey, privateKey } = genKeyPairAndSeed();
-const client = new SkynetClient("https://siasky.net");
+const client = new SkynetClient("https://siasky.dev");
 
 const dataKey = "HelloWorld";
 const maxint = BigInt("18446744073709551615"); // max uint64
 
 // skip - used to verify end-to-end flow
-describe("siasky.dev end to end integration test", () => {
+describe.skip("siasky.dev end to end integration test", () => {
   // NOTE: These tests must run sequentially.
   // https://jestjs.io/docs/en/setup-teardown.html#order-of-execution-of-describe-and-test-blocks
 
@@ -38,6 +38,8 @@ describe("siasky.dev end to end integration test", () => {
     const json = { data: "testnumber3" };
     const largeint = maxint + BigInt(1);
 
-    await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrow();
+    await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrowError(
+      "Received revision number > 2^64-1"
+    );
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,20 +1,34 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
 
 const { publicKey, privateKey } = genKeyPairAndSeed();
-const client = new SkynetClient("https://siasky.net");
+const client = new SkynetClient("https://siasky.dev");
 
 const datakey = "HelloWorld";
-const json = { data: "thisistext" };
 
 // skip - used to verify end-to-end flow
-describe("siasky.dev end to end integration test", () => {
+describe.skip("siasky.dev end to end integration test", () => {
   it("should be able to both setJSON and getJSON", async () => {
-    // set the file in the SkyDB
+    // Set and get a new entry (revision should be 0).
+
+    let json = { data: "thisistext" };
+
+    // Set the file in the SkyDB.
     await client.db.setJSON(privateKey, datakey, json);
 
     // get the file in the SkyDB
-    const actual = await client.db.getJSON(publicKey, datakey);
+    let actual = await client.db.getJSON(publicKey, datakey);
     expect(actual.data).toEqual(json);
-    expect(actual.revision).toEqual(0);
+    expect(actual.revision).toEqual(BigInt(0));
+
+    // Set the revision to the max allowed.
+
+    const maxint = BigInt("18446744073709551615"); // max uint64
+    json = { data: "testnumber2" };
+
+    await client.db.setJSON(privateKey, datakey, json, maxint);
+
+    actual = await client.db.getJSON(publicKey, datakey);
+    expect(actual.data).toEqual(json);
+    expect(actual.revision).toEqual(maxint);
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,6 +1,5 @@
 import { genKeyPairAndSeed, SkynetClient } from "./index";
 
-const { publicKey, privateKey } = genKeyPairAndSeed();
 const client = new SkynetClient("https://siasky.dev");
 
 const dataKey = "HelloWorld";
@@ -8,10 +7,8 @@ const maxint = BigInt("18446744073709551615"); // max uint64
 
 // skip - used to verify end-to-end flow
 describe.skip("siasky.dev end to end integration test", () => {
-  // NOTE: These tests must run sequentially.
-  // https://jestjs.io/docs/en/setup-teardown.html#order-of-execution-of-describe-and-test-blocks
-
-  test("Should set and get new entries", async () => {
+  it("Should set and get new entries", async () => {
+    const { publicKey, privateKey } = genKeyPairAndSeed();
     const json = { data: "thisistext" };
 
     // Set the file in the SkyDB.
@@ -24,7 +21,8 @@ describe.skip("siasky.dev end to end integration test", () => {
     expect(actual.revision).toEqual(BigInt(0));
   });
 
-  test("Should set and get entries with the revision at the max allowed", async () => {
+  it("Should set and get entries with the revision at the max allowed", async () => {
+    const { publicKey, privateKey } = genKeyPairAndSeed();
     const json = { data: "testnumber2" };
 
     await client.db.setJSON(privateKey, dataKey, json, maxint);
@@ -34,12 +32,13 @@ describe.skip("siasky.dev end to end integration test", () => {
     expect(actual.revision).toEqual(maxint);
   });
 
-  test("Try setting the revision higher than the uint64 max", async () => {
+  it("Try setting the revision higher than the uint64 max", async () => {
+    const { privateKey } = genKeyPairAndSeed();
     const json = { data: "testnumber3" };
     const largeint = maxint + BigInt(1);
 
     await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrowError(
-      "Received revision number > 2^64-1"
+      "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"
     );
   });
 });

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -75,13 +75,11 @@ export async function getEntry(
     return { entry: null, signature: null };
   }
 
-  // Convert the revision from a string to BigInt.
-  response.data.revision = BigInt(response.data.revision);
-
   const signedEntry = {
     entry: {
       datakey: dataKey,
       data: Buffer.from(hexToUint8Array(response.data.data)).toString(),
+      // Convert the revision from a string to bigint.
       revision: BigInt(response.data.revision),
     },
     signature: Buffer.from(hexToUint8Array(response.data.signature)),

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -15,10 +15,10 @@ const defaultSetEntryOptions = {
 };
 
 // Regex for JSON revision value without quotes.
-const regexRevisionNoQuotes = /"revision":\s?([0-9]+)/;
+const regexRevisionNoQuotes = /"revision":\s*([0-9]+)/;
 
 // Regex for JSON revision value with quotes.
-const regexRevisionWithQuotes = /"revision":\s?"([0-9]+)"/;
+const regexRevisionWithQuotes = /"revision":\s*"([0-9]+)"/;
 
 export type RegistryEntry = {
   datakey: string;

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,6 +14,12 @@ const defaultSetEntryOptions = {
   ...defaultOptions("/skynet/registry"),
 };
 
+// Regex for JSON revision value without quotes.
+const regexRevisionNoQuotes = /"revision":\s?([0-9]+)/;
+
+// Regex for JSON revision value with quotes.
+const regexRevisionWithQuotes = /"revision":\s?"([0-9]+)"/;
+
 export type RegistryEntry = {
   datakey: string;
   data: string;
@@ -60,7 +66,7 @@ export async function getEntry(
       // read by JS so the revision needs to be parsed as a string.
       transformResponse: function (data: string) {
         // Change the revision value from a JSON integer to a string.
-        data = data.replace(/"revision":([0-9]+)/, '"revision":"$1"');
+        data = data.replace(regexRevisionNoQuotes, '"revision":"$1"');
         // Convert the JSON data to an object.
         return JSON.parse(data);
       },
@@ -115,6 +121,9 @@ export function getEntryUrl(this: SkynetClient, publicKey: string, dataKey: stri
   return url;
 }
 
+/**
+ * @throws - Will throw if the entry revision does not fit in 64 bits.
+ */
 export async function setEntry(
   this: SkynetClient,
   privateKey: string,
@@ -162,7 +171,7 @@ export async function setEntry(
       // Convert the object data to JSON.
       const json = JSON.stringify(data);
       // Change the revision value from a string to a JSON integer.
-      return json.replace(/"revision":"([0-9]+)"/, '"revision":$1');
+      return json.replace(regexRevisionWithQuotes, '"revision":$1');
     },
   });
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -17,7 +17,7 @@ const defaultSetEntryOptions = {
 export type RegistryEntry = {
   datakey: string;
   data: string;
-  revision: number;
+  revision: bigint;
 };
 
 export type SignedRegistryEntry = {
@@ -70,8 +70,7 @@ export async function getEntry(
     entry: {
       datakey: dataKey,
       data: Buffer.from(hexToUint8Array(response.data.data)).toString(),
-      // TODO: Handle uint64 properly.
-      revision: parseInt(response.data.revision, 10),
+      revision: BigInt(response.data.revision),
     },
     signature: Buffer.from(hexToUint8Array(response.data.signature)),
   };
@@ -134,7 +133,7 @@ export async function setEntry(
       key: Array.from(publicKeyBuffer),
     },
     datakey: toHexString(hashDataKey(entry.datakey)),
-    revision: entry.revision,
+    revision: entry.revision.toString(),
     data: Array.from(Buffer.from(entry.data)),
     signature: Array.from(signature),
   };

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -121,6 +121,12 @@ export async function setEntry(
   entry: RegistryEntry,
   customOptions = {}
 ): Promise<void> {
+  // Assert the input is 64 bits.
+  const newint = BigInt.asUintN(64, entry.revision);
+  if (newint != entry.revision) {
+    throw new Error("Received revision number > 2^64-1");
+  }
+
   const opts = {
     ...defaultSetEntryOptions,
     ...this.customOptions,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,7 +1,7 @@
 import { pki } from "node-forge";
 import { AxiosResponse } from "axios";
 import { SkynetClient } from "./client";
-import { addUrlQuery, defaultOptions, hexToUint8Array, makeUrl, toHexString } from "./utils";
+import { addUrlQuery, checkUint64, defaultOptions, hexToUint8Array, makeUrl, toHexString } from "./utils";
 import { Buffer } from "buffer";
 import { hashDataKey, hashRegistryEntry, Signature } from "./crypto";
 
@@ -122,10 +122,7 @@ export async function setEntry(
   customOptions = {}
 ): Promise<void> {
   // Assert the input is 64 bits.
-  const newint = BigInt.asUintN(64, entry.revision);
-  if (newint != entry.revision) {
-    throw new Error("Received revision number > 2^64-1");
-  }
+  checkUint64(entry.revision);
 
   const opts = {
     ...defaultSetEntryOptions,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -62,8 +62,7 @@ export async function getEntry(
         // Change the revision value from a JSON integer to a string.
         data = data.replace(/"revision":([0-9]+)/, '"revision":"$1"');
         // Convert the JSON data to an object.
-        data = JSON.parse(data);
-        return data;
+        return JSON.parse(data);
       },
     });
   } catch (err: unknown) {
@@ -158,10 +157,9 @@ export async function setEntry(
     // parsed as a uint64 on the Go side.
     transformRequest: function (data: unknown) {
       // Convert the object data to JSON.
-      let json = JSON.stringify(data);
+      const json = JSON.stringify(data);
       // Change the revision value from a string to a JSON integer.
-      json = json.replace(/"revision":"([0-9]+)"/, '"revision":$1');
-      return json;
+      return json.replace(/"revision":"([0-9]+)"/, '"revision":$1');
     },
   });
 }

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-import { addUrlQuery, defaultSkynetPortalUrl, maxint } from "./utils";
+import { addUrlQuery, defaultSkynetPortalUrl, MAX_REVISION } from "./utils";
 import { SkynetClient, genKeyPairFromSeed } from "./index";
 
 const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
@@ -111,7 +111,7 @@ describe("setJSON", () => {
     // mock a successful registry lookup
     const entryData = {
       data,
-      revision: maxint.toString(),
+      revision: MAX_REVISION.toString(),
       signature:
         "18c76e88141c7cc76d8a77abcd91b5d64d8fc3833eae407ab8a5339e5fcf7940e3fa5830a8ad9439a0c0cc72236ed7b096ae05772f81eee120cbd173bfd6600e",
     };

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -107,6 +107,6 @@ describe("setJSON", () => {
 
     const data = JSON.parse(mock.history.post[1].data);
     expect(data).toBeDefined();
-    expect(data.revision).toEqual("0");
+    expect(data.revision).toEqual(0);
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -1,10 +1,10 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-import { addUrlQuery, defaultSkynetPortalUrl } from "./utils";
-import { SkynetClient, genKeyPairAndSeed } from "./index";
+import { addUrlQuery, defaultSkynetPortalUrl, maxint } from "./utils";
+import { SkynetClient, genKeyPairFromSeed } from "./index";
 
-const { publicKey, privateKey } = genKeyPairAndSeed();
+const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const dataKey = "app";
 const skylink = "CABAB_1Dt0FJsxqsu_J4TodNCbCGvtFf1Uys_3EgzOlTcg";
 const json = { data: "thisistext" };
@@ -14,6 +14,15 @@ const client = new SkynetClient(portalUrl);
 const registryUrl = `${portalUrl}/skynet/registry`;
 const registryLookupUrl = client.registry.getEntryUrl(publicKey, dataKey);
 const uploadUrl = `${portalUrl}/skynet/skyfile`;
+
+const data = "43414241425f31447430464a73787173755f4a34546f644e4362434776744666315579735f3345677a4f6c546367";
+const revision = 11;
+const entryData = {
+  data,
+  revision: revision.toString(),
+  signature:
+    "33d14d2889cb292142614da0e0ff13a205c4867961276001471d13b779fc9032568ddd292d9e0dff69d7b1f28be07972cc9d86da3cecf3adecb6f9b7311af809",
+};
 
 describe("getJSON", () => {
   let mock: MockAdapter;
@@ -26,13 +35,7 @@ describe("getJSON", () => {
   // TODO
   it.skip("should perform a lookup and skylink GET", async () => {
     // mock a successful registry lookup
-    const data = {
-      data: "41414333544f713757324a516c6a507567744d6a453555734a676973696b59624538465571677069646659486751",
-      revision: 11,
-      signature:
-        "7a971e1df2ddbb8ef1f8e71e28a5a64ffe1e5dfcb7eebb19e6c238744133ddeefc4f286488dd4500c33610711e3447b49e5a30df2e590e27ad00e56ebf3baf04",
-    };
-    mock.onGet(registryLookupUrl).reply(200, data);
+    mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
 
     // TODO mock skylink download request
 
@@ -61,12 +64,7 @@ describe("setJSON", () => {
     mock.onPost(uploadUrl).reply(200, { skylink });
 
     // mock a successful registry lookup
-    mock.onGet(registryLookupUrl).reply(200, {
-      data: "41414333544f713757324a516c6a507567744d6a453555734a676973696b59624538465571677069646659486751",
-      revision: 11,
-      signature:
-        "7a971e1df2ddbb8ef1f8e71e28a5a64ffe1e5dfcb7eebb19e6c238744133ddeefc4f286488dd4500c33610711e3447b49e5a30df2e590e27ad00e56ebf3baf04",
-    });
+    mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
 
     // mock a successful registry update
     mock.onPost(registryUrl).reply(204);
@@ -104,5 +102,27 @@ describe("setJSON", () => {
     const data = JSON.parse(mock.history.post[1].data);
     expect(data).toBeDefined();
     expect(data.revision).toEqual(0);
+  });
+
+  it("should fail if the entry has the maximum allowed revision", async () => {
+    // mock a successful upload
+    mock.onPost(uploadUrl).reply(200, { skylink });
+
+    // mock a successful registry lookup
+    const entryData = {
+      data,
+      revision: maxint.toString(),
+      signature:
+        "18c76e88141c7cc76d8a77abcd91b5d64d8fc3833eae407ab8a5339e5fcf7940e3fa5830a8ad9439a0c0cc72236ed7b096ae05772f81eee120cbd173bfd6600e",
+    };
+    mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
+
+    // mock a successful registry update
+    mock.onPost(registryUrl).reply(204);
+
+    // Try to set data, should fail.
+    await expect(client.db.setJSON(privateKey, dataKey, json)).rejects.toThrowError(
+      "Current entry already has maximum allowed revision, could not update the entry"
+    );
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -107,6 +107,6 @@ describe("setJSON", () => {
 
     const data = JSON.parse(mock.history.post[1].data);
     expect(data).toBeDefined();
-    expect(data.revision).toEqual(0);
+    expect(data.revision).toEqual("0");
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -72,9 +72,7 @@ describe("setJSON", () => {
     mock.onPost(registryUrl).reply(204);
 
     // set data
-    const updated = await client.db.setJSON(privateKey, dataKey, json);
-
-    expect(updated);
+    await client.db.setJSON(privateKey, dataKey, json);
 
     // assert our request history contains the expected amount of requests
     expect(mock.history.get.length).toBe(1);
@@ -97,9 +95,7 @@ describe("setJSON", () => {
     mock.onPost(registryUrl).reply(204);
 
     // call `setJSON` on the client
-    const updated = await client.db.setJSON(privateKey, dataKey, json);
-
-    expect(updated);
+    await client.db.setJSON(privateKey, dataKey, json);
 
     // assert our request history contains the expected amount of requests
     expect(mock.history.get.length).toBe(1);

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -1,7 +1,7 @@
 import { pki } from "node-forge";
 import { SkynetClient } from "./client";
 import { RegistryEntry, SignedRegistryEntry } from "./registry";
-import { parseSkylink, trimUriPrefix, uriSkynetPrefix, toHexString } from "./utils";
+import { parseSkylink, trimUriPrefix, uriSkynetPrefix, toHexString, checkUint64 } from "./utils";
 import { Buffer } from "buffer";
 
 /**
@@ -76,10 +76,7 @@ export async function setJSON(
     }
   } else {
     // Assert the input is 64 bits.
-    const newint = BigInt.asUintN(64, revision);
-    if (newint != revision) {
-      throw new Error("Received revision number > 2^64-1");
-    }
+    checkUint64(revision);
   }
 
   // build the registry value

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -74,6 +74,12 @@ export async function setJSON(
     } catch (err) {
       revision = BigInt(0);
     }
+  } else {
+    // Assert the input is 64 bits.
+    const newint = BigInt.asUintN(64, revision);
+    if (newint != revision) {
+      throw new Error("Received revision number > 2^64-1");
+    }
   }
 
   // build the registry value

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -1,7 +1,7 @@
 import { pki } from "node-forge";
 import { SkynetClient } from "./client";
 import { RegistryEntry, SignedRegistryEntry } from "./registry";
-import { parseSkylink, trimUriPrefix, uriSkynetPrefix, toHexString, checkUint64, maxint } from "./utils";
+import { parseSkylink, trimUriPrefix, uriSkynetPrefix, toHexString, checkUint64, MAX_REVISION } from "./utils";
 import { Buffer } from "buffer";
 
 /**
@@ -73,7 +73,7 @@ export async function setJSON(
     }
 
     // Throw if the revision is already the maximum value.
-    if (revision > maxint) {
+    if (revision > MAX_REVISION) {
       throw new Error("Current entry already has maximum allowed revision, could not update the entry");
     }
   } else {

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -16,7 +16,7 @@ export async function getJSON(
   publicKey: string,
   dataKey: string,
   customOptions = {}
-): Promise<{ data: Record<string, unknown>; revision: number } | null> {
+): Promise<{ data: Record<string, unknown>; revision: bigint } | null> {
   const opts = {
     ...this.customOptions,
     ...customOptions,
@@ -49,7 +49,7 @@ export async function setJSON(
   privateKey: string,
   dataKey: string,
   json: Record<string, unknown>,
-  revision?: number,
+  revision?: bigint,
   customOptions = {}
 ): Promise<void> {
   const opts = {
@@ -70,9 +70,9 @@ export async function setJSON(
     try {
       const publicKey = pki.ed25519.publicKeyFromPrivateKey({ privateKey: privateKeyBuffer });
       entry = await this.registry.getEntry(toHexString(publicKey), dataKey, opts);
-      revision = entry.entry.revision + 1;
+      revision = entry.entry.revision + BigInt(1);
     } catch (err) {
-      revision = 0;
+      revision = BigInt(0);
     }
   }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -5,7 +5,7 @@ import {
   defaultSkynetPortalUrl,
   getFileMimeType,
   makeUrl,
-  maxint,
+  MAX_REVISION,
   parseSkylink,
   trimUriPrefix,
   uriHandshakePrefix,
@@ -37,8 +37,8 @@ describe("checkUint64", () => {
   it("should test the checkUint64 function", () => {
     expect(() => checkUint64(BigInt(0))).not.toThrow();
     expect(() => checkUint64(BigInt(-1))).toThrow();
-    expect(() => checkUint64(maxint)).not.toThrow();
-    expect(() => checkUint64(maxint + BigInt(1))).toThrow();
+    expect(() => checkUint64(MAX_REVISION)).not.toThrow();
+    expect(() => checkUint64(MAX_REVISION + BigInt(1))).toThrow();
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -8,6 +8,7 @@ import {
   uriHandshakeResolverPrefix,
   getFileMimeType,
   convertSkylinkToBase32,
+  checkUint64,
 } from "./utils";
 import { combineStrings, extractNonSkylinkPath } from "../utils/testing";
 
@@ -28,6 +29,17 @@ describe("addUrlQuery", () => {
       `${portalUrl}/?attachment=true&foo=bar`
     );
     expect(addUrlQuery(`${portalUrl}#foobar`, { foo: "bar" })).toEqual(`${portalUrl}?foo=bar#foobar`);
+  });
+});
+
+describe("checkUint64", () => {
+  it("should test the checkUint64 function", () => {
+    const maxint = BigInt("18446744073709551615"); // max uint64
+
+    expect(() => checkUint64(BigInt(0))).not.toThrow();
+    expect(() => checkUint64(BigInt(-1))).toThrow();
+    expect(() => checkUint64(maxint)).not.toThrow();
+    expect(() => checkUint64(maxint + BigInt(1))).toThrow();
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,14 +1,15 @@
 import {
   addUrlQuery,
+  checkUint64,
+  convertSkylinkToBase32,
   defaultSkynetPortalUrl,
+  getFileMimeType,
   makeUrl,
+  maxint,
   parseSkylink,
   trimUriPrefix,
   uriHandshakePrefix,
   uriHandshakeResolverPrefix,
-  getFileMimeType,
-  convertSkylinkToBase32,
-  checkUint64,
 } from "./utils";
 import { combineStrings, extractNonSkylinkPath } from "../utils/testing";
 
@@ -34,8 +35,6 @@ describe("addUrlQuery", () => {
 
 describe("checkUint64", () => {
   it("should test the checkUint64 function", () => {
-    const maxint = BigInt("18446744073709551615"); // max uint64
-
     expect(() => checkUint64(BigInt(0))).not.toThrow();
     expect(() => checkUint64(BigInt(-1))).toThrow();
     expect(() => checkUint64(maxint)).not.toThrow();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,19 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
   return parsed.toString();
 }
 
+// From https://stackoverflow.com/a/60818105/6085242
+export function areEqualUint8Arrays(array1: Uint8Array, array2: Uint8Array): boolean {
+  if (array1.length != array2.length) {
+    return false;
+  }
+  for (let i = 0; i < array1.length; i++) {
+    if (array1[i] != array2[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function convertSkylinkToBase32(input: string): string {
   const decoded = base64.toByteArray(input.padEnd(input.length + 4 - (input.length % 4), "="));
   return base32Encode(decoded, "RFC4648-HEX", { padding: false }).toLowerCase();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,25 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
   return parsed.toString();
 }
 
+/**
+ * Checks if the provided bigint can fit in a 64-bit unsigned integer.
+ *
+ * @param int - The provided integer.
+ * @throws - Will throw if the int does not fit in 64 bits.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN | MDN Demo}
+ */
+export function checkUint64(int: bigint) {
+  const maxint = BigInt("18446744073709551615"); // max uint64
+
+  if (int < 0) {
+    throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);
+  }
+
+  if (int > maxint) {
+    throw new Error(`Argument ${int} does not fit in a 64-bit unsigned integer; exceeds 2^64-1`);
+  }
+}
+
 export function convertSkylinkToBase32(input: string): string {
   const decoded = base64.toByteArray(input.padEnd(input.length + 4 - (input.length % 4), "="));
   return base32Encode(decoded, "RFC4648-HEX", { padding: false }).toLowerCase();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,19 +33,6 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
   return parsed.toString();
 }
 
-// From https://stackoverflow.com/a/60818105/6085242
-export function areEqualUint8Arrays(array1: Uint8Array, array2: Uint8Array): boolean {
-  if (array1.length != array2.length) {
-    return false;
-  }
-  for (let i = 0; i < array1.length; i++) {
-    if (array1[i] != array2[i]) {
-      return false;
-    }
-  }
-  return true;
-}
-
 export function convertSkylinkToBase32(input: string): string {
   const decoded = base64.toByteArray(input.padEnd(input.length + 4 - (input.length % 4), "="));
   return base32Encode(decoded, "RFC4648-HEX", { padding: false }).toLowerCase();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,7 @@ export const uriHandshakePrefix = "hns:";
 export const uriHandshakeResolverPrefix = "hnsres:";
 export const uriSkynetPrefix = "sia:";
 
-const maxint = BigInt("18446744073709551615"); // max uint64
+export const maxint = BigInt("18446744073709551615"); // max uint64
 
 // TODO: Use a third-party library to make this more robust.
 export function addSubdomain(url: string, subdomain: string): string {
@@ -43,7 +43,7 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN | MDN Demo}
  */
 export function checkUint64(int: bigint) {
-  if (int < 0) {
+  if (int < BigInt(0)) {
     throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,10 @@ export const uriHandshakePrefix = "hns:";
 export const uriHandshakeResolverPrefix = "hnsres:";
 export const uriSkynetPrefix = "sia:";
 
-export const maxint = BigInt("18446744073709551615"); // max uint64
+/**
+ * The maximum allowed value for an entry revision. Setting an entry revision to this value prevents it from being updated further.
+ */
+export const MAX_REVISION = BigInt("18446744073709551615"); // max uint64
 
 // TODO: Use a third-party library to make this more robust.
 export function addSubdomain(url: string, subdomain: string): string {
@@ -47,7 +50,7 @@ export function checkUint64(int: bigint) {
     throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);
   }
 
-  if (int > maxint) {
+  if (int > MAX_REVISION) {
     throw new Error(`Argument ${int} does not fit in a 64-bit unsigned integer; exceeds 2^64-1`);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ export const uriHandshakePrefix = "hns:";
 export const uriHandshakeResolverPrefix = "hnsres:";
 export const uriSkynetPrefix = "sia:";
 
+const maxint = BigInt("18446744073709551615"); // max uint64
+
 // TODO: Use a third-party library to make this more robust.
 export function addSubdomain(url: string, subdomain: string): string {
   const urlObj = new URL(url);
@@ -41,8 +43,6 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN | MDN Demo}
  */
 export function checkUint64(int: bigint) {
-  const maxint = BigInt("18446744073709551615"); // max uint64
-
   if (int < 0) {
     throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);
   }


### PR DESCRIPTION
The revision number needs to be a `bigint` instead of `number` to support the full range of accepted revisions on the Sia side (uint64 has a wider range than allowed in 53 bits, the max for `number` in JS).

**This is a breaking change.**