### PR TITLE
Only return nulls if registry entry is nonexistent 

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -134,7 +134,7 @@ function encodeString(str: string): Uint8Array {
 export function deriveChildSeed(masterSeed: string, seed: string): string {
   /* istanbul ignore next */
   if (typeof masterSeed !== "string") {
-    throw new Error(`Expected parameter masterSeed to be type string, was type ${typeof seed}`);
+    throw new Error(`Expected parameter masterSeed to be type string, was type ${typeof masterSeed}`);
   }
   /* istanbul ignore next */
   if (typeof seed !== "string") {

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -132,6 +132,15 @@ function encodeString(str: string): Uint8Array {
  * @returns - The child seed derived from `masterSeed` using `seed`.
  */
 export function deriveChildSeed(masterSeed: string, seed: string): string {
+  /* istanbul ignore next */
+  if (typeof masterSeed !== "string") {
+    throw new Error(`Expected parameter masterSeed to be type string, was type ${typeof seed}`);
+  }
+  /* istanbul ignore next */
+  if (typeof seed !== "string") {
+    throw new Error(`Expected parameter seed to be type string, was type ${typeof seed}`);
+  }
+
   return toHexString(hashAll(encodeString(masterSeed), encodeString(seed)));
 }
 
@@ -153,6 +162,11 @@ export function genKeyPairAndSeed(length = 64): KeyPairAndSeed {
  * @returns - The generated key pair.
  */
 export function genKeyPairFromSeed(seed: string): KeyPair {
+  /* istanbul ignore next */
+  if (typeof seed !== "string") {
+    throw new Error(`Expected parameter seed to be type string, was type ${typeof seed}`);
+  }
+
   // Get a 32-byte seed.
   seed = pkcs5.pbkdf2(seed, "", 1000, 32, md.sha256.create());
   const { publicKey, privateKey } = pki.ed25519.generateKeyPair({ seed });

--- a/src/download.ts
+++ b/src/download.ts
@@ -67,6 +67,11 @@ const defaultResolveHnsOptions = {
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
 export function downloadFile(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
+
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions, download: true };
   const url = this.getSkylinkUrl(skylinkUrl, opts);
 
@@ -90,6 +95,11 @@ export async function downloadFileHns(
   domain: string,
   customOptions?: CustomDownloadOptions
 ): Promise<string> {
+  /* istanbul ignore next */
+  if (typeof domain !== "string") {
+    throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
+  }
+
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions, download: true };
   const url = this.getHnsUrl(domain, opts);
 
@@ -110,6 +120,11 @@ export async function downloadFileHns(
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
 export function getSkylinkUrl(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
+
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const query = opts.query ?? {};
   if (opts.download) {
@@ -168,6 +183,11 @@ export function getSkylinkUrl(this: SkynetClient, skylinkUrl: string, customOpti
  * @returns - The full URL for the HNS domain.
  */
 export function getHnsUrl(this: SkynetClient, domain: string, customOptions?: CustomHnsDownloadOptions): string {
+  /* istanbul ignore next */
+  if (typeof domain !== "string") {
+    throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
+  }
+
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions };
   const query = opts.query ?? {};
   if (opts.download) {
@@ -191,6 +211,11 @@ export function getHnsUrl(this: SkynetClient, domain: string, customOptions?: Cu
  * @returns - The full URL for the resolver for the HNS domain.
  */
 export function getHnsresUrl(this: SkynetClient, domain: string, customOptions?: BaseCustomOptions): string {
+  /* istanbul ignore next */
+  if (typeof domain !== "string") {
+    throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
+  }
+
   const opts = { ...defaultResolveHnsOptions, ...this.customOptions, ...customOptions };
 
   domain = trimUriPrefix(domain, uriHandshakeResolverPrefix);
@@ -212,6 +237,11 @@ export async function getMetadata(
   skylinkUrl: string,
   customOptions?: CustomDownloadOptions
 ): Promise<Record<string, unknown>> {
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
+
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylinkUrl, opts);
 
@@ -228,7 +258,7 @@ export async function getMetadata(
  * Does a GET request of the skylink, returning the data property of the response.
  *
  * @param this - SkynetClient
- * @param skylink - 46 character skylink.
+ * @param skylinkUrl - Skylink string. See `downloadFile`.
  * @param [customOptions] - Additional settings that can optionally be set.
  * @param [customOptions.endpointPath="/"] - The relative URL path of the portal endpoint to contact.
  * @returns - The content of the file.
@@ -236,13 +266,18 @@ export async function getMetadata(
  */
 export async function getFileContent(
   this: SkynetClient,
-  skylink: string,
+  skylinkUrl: string,
   customOptions?: CustomDownloadOptions
 ): Promise<Record<string, unknown>> {
-  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
-  const url = this.getSkylinkUrl(skylink, opts);
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
 
-  // GET request the skylink
+  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
+  const url = this.getSkylinkUrl(skylinkUrl, opts);
+
+  // GET request the skylink.
   const response = await this.executeRequest({
     ...opts,
     method: "get",
@@ -263,6 +298,11 @@ export async function getFileContent(
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
 export function openFile(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
+
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylinkUrl, opts);
 
@@ -285,6 +325,11 @@ export async function openFileHns(
   domain: string,
   customOptions?: CustomHnsDownloadOptions
 ): Promise<string> {
+  /* istanbul ignore next */
+  if (typeof domain !== "string") {
+    throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
+  }
+
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions };
   const url = this.getHnsUrl(domain, opts);
 
@@ -308,6 +353,11 @@ export async function resolveHns(
   domain: string,
   customOptions?: BaseCustomOptions
 ): Promise<ResolveHnsResponse> {
+  /* istanbul ignore next */
+  if (typeof domain !== "string") {
+    throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
+  }
+
   const opts = { ...defaultResolveHnsOptions, ...this.customOptions, ...customOptions };
   const url = this.getHnsresUrl(domain, opts);
 

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -9,6 +9,15 @@ const dataKey = "HelloWorld";
 
 // Used to verify end-to-end flow.
 describe("SkyDB end to end integration tests", () => {
+  it("Should return null for an inexistent entry", async () => {
+    const { publicKey } = genKeyPairAndSeed();
+
+    // Try getting an inexistent entry.
+    const { data, revision } = await client.db.getJSON(publicKey, "foo");
+    expect(data).toBeNull();
+    expect(revision).toBeNull();
+  });
+
   it("Should set and get new entries", async () => {
     const { publicKey, privateKey } = genKeyPairAndSeed();
     const json = { data: "thisistext" };

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -26,10 +26,10 @@ describe("SkyDB end to end integration tests", () => {
     await client.db.setJSON(privateKey, dataKey, json);
 
     // get the file in the SkyDB
-    const actual = await client.db.getJSON(publicKey, dataKey);
-    expect(actual.data).toEqual(json);
+    const { data, revision } = await client.db.getJSON(publicKey, dataKey);
+    expect(data).toEqual(json);
     // Revision should be 0.
-    expect(actual.revision).toEqual(BigInt(0));
+    expect(revision).toEqual(BigInt(0));
   });
 
   it("Should set and get entries with the revision at the max allowed", async () => {

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -60,7 +60,7 @@ describe("getEntry", () => {
 
   it("Should throw an error if the public key is not hex-encoded", async () => {
     await expect(client.registry.getEntry("foo", dataKey)).rejects.toThrowError(
-      "Expected parameter publicKey to be a hex-encoded string"
+      "Given public key 'foo' is not a valid hex-encoded string or contains an invalid prefix"
     );
   });
 
@@ -110,7 +110,7 @@ describe("setEntry", () => {
 
   it("should throw when key is not hex-encoded", async () => {
     await expect(client.registry.setEntry(`${privateKey}x`, {})).rejects.toThrowError(
-      `Given private key '${privateKey}x' is not a valid hex-encoded string`
+      "Expected parameter privateKey to be a hex-encoded string"
     );
   });
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -4,7 +4,7 @@ import { genKeyPairAndSeed } from "./crypto";
 import { SkynetClient, defaultSkynetPortalUrl, genKeyPairFromSeed } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 
-const { publicKey } = genKeyPairFromSeed("insecure test seed");
+const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const portalUrl = defaultSkynetPortalUrl;
 const client = new SkynetClient(portalUrl);
 const dataKey = "app";
@@ -98,5 +98,9 @@ describe("setEntry", () => {
     await expect(client.registry.setEntry("foo", {})).rejects.toThrowError(
       "Expected parameter privateKey to be a hex-encoded string"
     );
+  });
+
+  it("Should throw an error if the entry is not an object", async () => {
+    await expect(client.registry.setEntry(privateKey)).rejects.toThrowError("Expected parameter entry to be an object");
   });
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -10,13 +10,6 @@ const client = new SkynetClient(portalUrl);
 const dataKey = "app";
 
 const registryLookupUrl = client.registry.getEntryUrl(publicKey, dataKey);
-const entryData = {
-  data: "43414241425f31447430464a73787173755f4a34546f644e4362434776744666315579735f3345677a4f6c546367",
-  revision: "11",
-  signature:
-    "33d14d2889cb292142614da0e0ff13a205c4867961276001471d13b779fc9032568ddd292d9e0dff69d7b1f28be07972cc9d86da3cecf3adecb6f9b7311af809",
-};
-const json = JSON.stringify(entryData);
 
 describe("getEntry", () => {
   let mock: MockAdapter;
@@ -26,20 +19,10 @@ describe("getEntry", () => {
     mock.resetHistory();
   });
 
-  it("should return null if the response status is in the 200s but not 200", async () => {
-    mock.onGet(registryLookupUrl).reply(201, json);
+  it("should throw if the response status is not in the 200s and not 404", async () => {
+    mock.onGet(registryLookupUrl).reply(400, JSON.stringify({ message: "foo error" }));
 
-    const { entry, signature } = await client.registry.getEntry(publicKey, dataKey);
-    expect(entry).toBeNull();
-    expect(signature).toBeNull();
-  });
-
-  it("should return null if the response status is not in the 200s", async () => {
-    mock.onGet(registryLookupUrl).reply(300, json);
-
-    const { entry, signature } = await client.registry.getEntry(publicKey, dataKey);
-    expect(entry).toBeNull();
-    expect(signature).toBeNull();
+    await expect(client.registry.getEntry(publicKey, dataKey)).rejects.toThrowError("foo error");
   });
 
   it("should throw if the signature could not be verified", async () => {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -90,17 +90,7 @@ export async function getEntry(
   dataKey: string,
   customOptions?: CustomGetEntryOptions
 ): Promise<SignedRegistryEntry> {
-  /* istanbul ignore next */
-  if (typeof publicKey !== "string") {
-    throw new Error(`Expected parameter publicKey to be type string, was type ${typeof publicKey}`);
-  }
-  /* istanbul ignore next */
-  if (typeof dataKey !== "string") {
-    throw new Error(`Expected parameter dataKey to be type string, was type ${typeof dataKey}`);
-  }
-  if (!isHexString(publicKey)) {
-    throw new Error("Expected parameter publicKey to be a hex-encoded string");
-  }
+  // Validation is done in `getEntryUrl`.
 
   const opts = {
     ...defaultGetEntryOptions,
@@ -108,8 +98,8 @@ export async function getEntry(
     ...customOptions,
   };
 
-  const publicKeyBuffer = Buffer.from(publicKey, "hex");
   const url = this.registry.getEntryUrl(publicKey, dataKey, opts);
+  const publicKeyBuffer = Buffer.from(publicKey, "hex");
 
   let response: AxiosResponse;
   try {
@@ -188,6 +178,15 @@ export function getEntryUrl(
   dataKey: string,
   customOptions?: CustomGetEntryOptions
 ): string {
+  /* istanbul ignore next */
+  if (typeof publicKey !== "string") {
+    throw new Error(`Expected parameter publicKey to be type string, was type ${typeof publicKey}`);
+  }
+  /* istanbul ignore next */
+  if (typeof dataKey !== "string") {
+    throw new Error(`Expected parameter dataKey to be type string, was type ${typeof dataKey}`);
+  }
+
   const opts = {
     ...defaultGetEntryOptions,
     ...this.customOptions,
@@ -248,10 +247,6 @@ export async function setEntry(
 
   // Assert the input is 64 bits.
   assertUint64(entry.revision);
-
-  if (!isHexString(privateKey)) {
-    throw new Error(`Given private key '${privateKey}' is not a valid hex-encoded string`);
-  }
 
   const opts = {
     ...defaultSetEntryOptions,

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -232,6 +232,9 @@ export async function setEntry(
   if (!isHexString(privateKey)) {
     throw new Error("Expected parameter privateKey to be a hex-encoded string");
   }
+  if (typeof entry !== "object" || entry === null) {
+    throw new Error("Expected parameter entry to be an object");
+  }
 
   // Assert the input is 64 bits.
   assertUint64(entry.revision);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -137,12 +137,15 @@ export async function getEntry(
     throw new Error(err.response.data.message);
   }
 
+  // Sanity check.
   if (
-    typeof response.data.data != "string" ||
-    typeof response.data.revision != "string" ||
-    typeof response.data.signature != "string"
+    typeof response.data.data !== "string" ||
+    typeof response.data.revision !== "string" ||
+    typeof response.data.signature !== "string"
   ) {
-    throw new Error("Did not get a complete entry response");
+    throw new Error(
+      "Did not get a complete entry response despite a successful request. Please try again and report this issue to the devs if it persists"
+    );
   }
 
   const signedEntry = {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -144,7 +144,7 @@ export async function getEntry(
     typeof response.data.signature !== "string"
   ) {
     throw new Error(
-      "Did not get a complete entry response despite a successful request. Please try again and report this issue to the devs if it persists"
+      "Did not get a complete entry response despite a successful request. Please try again and report this issue to the devs if it persists."
     );
   }
 

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -44,7 +44,7 @@ describe("getJSON", () => {
   });
 
   it("should return null if no entry is found", async () => {
-    mock.onGet(registryLookupUrl).reply(400);
+    mock.onGet(registryLookupUrl).reply(404);
 
     const { data, revision } = await client.db.getJSON(publicKey, dataKey);
     expect(data).toBeNull();
@@ -106,7 +106,7 @@ describe("setJSON", () => {
     // mock a successful upload
     mock.onPost(uploadUrl).reply(200, { skylink });
 
-    mock.onGet(registryLookupUrl).reply(400);
+    mock.onGet(registryLookupUrl).reply(404);
 
     // mock a successful registry update
     mock.onPost(registryUrl).reply(204);

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -147,4 +147,10 @@ describe("setJSON", () => {
       "Current entry already has maximum allowed revision, could not update the entry"
     );
   });
+
+  it("Should throw an error if the private key is not hex-encoded", async () => {
+    await expect(client.db.setJSON("foo", dataKey, {})).rejects.toThrowError(
+      "Expected parameter privateKey to be a hex-encoded string"
+    );
+  });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -154,7 +154,15 @@ describe("setJSON", () => {
     );
   });
 
-  it("Should throw an error if the json is not an object", async () => {
-    await expect(client.registry.setEntry(privateKey)).rejects.toThrowError("Expected parameter entry to be an object");
+  it("Should throw an error if the data key is not provided", async () => {
+    await expect(client.db.setJSON(privateKey)).rejects.toThrowError(
+      "Expected parameter dataKey to be type string, was type undefined"
+    );
+  });
+
+  it("Should throw an error if the json is not provided", async () => {
+    await expect(client.db.setJSON(privateKey, dataKey)).rejects.toThrowError(
+      "Expected parameter json to be an object"
+    );
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -143,7 +143,7 @@ describe("setJSON", () => {
     mock.onPost(registryUrl).reply(204);
 
     // Try to set data, should fail.
-    await expect(client.db.setJSON(privateKey, dataKey, json)).rejects.toThrowError(
+    await expect(client.db.setJSON(privateKey, dataKey, entryData)).rejects.toThrowError(
       "Current entry already has maximum allowed revision, could not update the entry"
     );
   });
@@ -152,5 +152,9 @@ describe("setJSON", () => {
     await expect(client.db.setJSON("foo", dataKey, {})).rejects.toThrowError(
       "Expected parameter privateKey to be a hex-encoded string"
     );
+  });
+
+  it("Should throw an error if the json is not an object", async () => {
+    await expect(client.registry.setEntry(privateKey)).rejects.toThrowError("Expected parameter entry to be an object");
   });
 });

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -84,13 +84,12 @@ export async function setJSON(
 
   if (revision === undefined) {
     // fetch the current value to find out the revision.
-    let entry: SignedRegistryEntry;
-    try {
-      const publicKey = pki.ed25519.publicKeyFromPrivateKey({ privateKey: privateKeyBuffer });
-      entry = await this.registry.getEntry(toHexString(publicKey), dataKey, opts);
-      revision = entry.entry.revision + BigInt(1);
-    } catch (err) {
+    const publicKey = pki.ed25519.publicKeyFromPrivateKey({ privateKey: privateKeyBuffer });
+    const entry: SignedRegistryEntry = await this.registry.getEntry(toHexString(publicKey), dataKey, opts);
+    if (entry.entry === null) {
       revision = BigInt(0);
+    } else {
+      revision = entry.entry.revision + BigInt(1);
     }
 
     // Throw if the revision is already the maximum value.

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -1,7 +1,15 @@
 import { pki } from "node-forge";
 import { SkynetClient } from "./client";
 import { CustomGetEntryOptions, RegistryEntry, SignedRegistryEntry, CustomSetEntryOptions } from "./registry";
-import { trimUriPrefix, uriSkynetPrefix, toHexString, assertUint64, MAX_REVISION, BaseCustomOptions } from "./utils";
+import {
+  trimUriPrefix,
+  uriSkynetPrefix,
+  toHexString,
+  assertUint64,
+  MAX_REVISION,
+  BaseCustomOptions,
+  isHexString,
+} from "./utils";
 import { Buffer } from "buffer";
 import { CustomUploadOptions } from "./upload";
 import { CustomDownloadOptions } from "./download";
@@ -75,6 +83,18 @@ export async function setJSON(
   revision?: bigint,
   customOptions?: CustomSetJSONOptions
 ): Promise<void> {
+  /* istanbul ignore next */
+  if (typeof privateKey !== "string") {
+    throw new Error(`Expected parameter privateKey to be type string, was type ${typeof privateKey}`);
+  }
+  /* istanbul ignore next */
+  if (typeof dataKey !== "string") {
+    throw new Error(`Expected parameter dataKey to be type string, was type ${typeof dataKey}`);
+  }
+  if (!isHexString(privateKey)) {
+    throw new Error("Expected parameter privateKey to be a hex-encoded string");
+  }
+
   const opts = {
     ...this.customOptions,
     ...customOptions,

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -94,6 +94,9 @@ export async function setJSON(
   if (!isHexString(privateKey)) {
     throw new Error("Expected parameter privateKey to be a hex-encoded string");
   }
+  if (typeof json !== "object" || json === null) {
+    throw new Error("Expected parameter json to be an object");
+  }
 
   const opts = {
     ...this.customOptions,

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -130,6 +130,13 @@ describe("uploadFile", () => {
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
     await expect(client.uploadFile(file, { skykeyId: "test" })).rejects.toThrow();
   });
+
+  it("should throw if a skylink was not returned", async () => {
+    mock.resetHandlers();
+    mock.onPost(url).replyOnce(200, {});
+
+    await expect(client.uploadFile(file)).rejects.toThrowError("Did not get expected skylink response");
+  });
 });
 
 describe("uploadDirectory", () => {

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -45,7 +45,9 @@ export async function uploadFile(this: SkynetClient, file: File, customOptions?:
   const response = await this.uploadFileRequest(file, customOptions);
 
   if (typeof response.skylink !== "string") {
-    throw new Error("Did not get expected skylink response");
+    throw new Error(
+      "Did not get expected skylink response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   }
 
   return `${uriSkynetPrefix}${response.skylink}`;

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -44,6 +44,10 @@ const defaultUploadOptions = {
 export async function uploadFile(this: SkynetClient, file: File, customOptions?: CustomUploadOptions): Promise<string> {
   const response = await this.uploadFileRequest(file, customOptions);
 
+  if (typeof response.skylink !== "string") {
+    throw new Error("Did not get expected skylink response");
+  }
+
   return `${uriSkynetPrefix}${response.skylink}`;
 }
 
@@ -117,6 +121,11 @@ export async function uploadDirectoryRequest(
   filename: string,
   customOptions?: CustomUploadOptions
 ): Promise<UploadRequestResponse> {
+  /* istanbul ignore next */
+  if (typeof filename !== "string") {
+    throw new Error(`Expected parameter filename to be type string, was type ${typeof filename}`);
+  }
+
   const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
   const formData = new FormData();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,6 +81,11 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN | MDN Demo}
  */
 export function assertUint64(int: bigint): void {
+  /* istanbul ignore next */
+  if (typeof int !== "bigint") {
+    throw new Error(`Expected parameter int to be type bigint, was type ${typeof int}`);
+  }
+
   if (int < BigInt(0)) {
     throw new Error(`Argument ${int} must be an unsigned 64-bit integer; was negative`);
   }
@@ -331,6 +336,11 @@ export function trimUriPrefix(str: string, prefix: string): string {
  * @returns - The uint8 array.
  */
 export function stringToUint8Array(str: string): Uint8Array {
+  /* istanbul ignore next */
+  if (typeof str !== "string") {
+    throw new Error(`Expected parameter str to be type string, was type ${typeof str}`);
+  }
+
   return Uint8Array.from(Buffer.from(str));
 }
 
@@ -341,7 +351,22 @@ export function stringToUint8Array(str: string): Uint8Array {
  * @returns - The uint8 array.
  */
 export function hexToUint8Array(str: string): Uint8Array {
+  /* istanbul ignore next */
+  if (typeof str !== "string") {
+    throw new Error(`Expected parameter str to be type string, was type ${typeof str}`);
+  }
+
   return new Uint8Array(str.match(/.{1,2}/g).map((byte) => parseInt(byte, 16)));
+}
+
+/**
+ * Returns true if the input is a valid hex-encoded string.
+ *
+ * @param str - The input string.
+ * @returns - True if the input is hex-encoded.
+ */
+export function isHexString(str: string): boolean {
+  return /^[0-9A-Fa-f]*$/g.test(str);
 }
 
 /**


### PR DESCRIPTION
- Only return `null` from `getEntry` if registry entry is nonexistent

- Adds some checks on data returned from GET calls 

- Also adds typechecking to most of the exported functions. It is still missing some checks for objects but I got all the low-hanging fruit.

This should give more user-friendly errors than before, with actionable feedback. For example, calling `genKeyPairFromSeed` without the seed input would previously throw `Uncaught TypeError: Cannot read property 'length' of undefined`. Now it should throw `Expected parameter seed to be type string, was type undefined`.

Closes #220

