### PR TITLE
getFileContent should return a string and not object

### DIFF
--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -193,8 +193,16 @@ describe("getFileContent", () => {
 
       const fileData = await client.getFileContent(input);
 
-      expect(fileData).toEqual(skynetFileContents);
+      expect(fileData).toEqual(JSON.stringify(skynetFileContents));
     });
+  });
+
+  it("should throw if data is not returned", async () => {
+    mock.onGet(expectedUrl).reply(200);
+
+    await expect(client.getFileContent(skylink)).rejects.toThrowError(
+      "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   });
 });
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -193,7 +193,7 @@ describe("getFileContent", () => {
 
       const fileData = await client.getFileContent(input);
 
-      expect(fileData).toEqual(JSON.stringify(skynetFileContents));
+      expect(fileData).toEqual(skynetFileContents);
     });
   });
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -234,29 +234,25 @@ export async function getMetadata(
  * @returns - The content of the file.
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
-export async function getFileContent(
+export async function getFileContent<T = unknown>(
   this: SkynetClient,
   skylink: string,
   customOptions?: CustomDownloadOptions
-): Promise<string> {
+): Promise<T> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylink, opts);
 
   // GET request the skylink
-  let { data } = await this.executeRequest({
+  const { data } = await this.executeRequest({
     ...opts,
     method: "get",
     url,
   });
 
-  if (typeof data !== "string") {
-    if (typeof data === "object" && data !== null) {
-      data = JSON.stringify(data);
-    } else {
-      throw new Error(
-        "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
-      );
-    }
+  if (typeof data === "undefined") {
+    throw new Error(
+      "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   }
 
   return data;

--- a/src/download.ts
+++ b/src/download.ts
@@ -238,18 +238,28 @@ export async function getFileContent(
   this: SkynetClient,
   skylink: string,
   customOptions?: CustomDownloadOptions
-): Promise<Record<string, unknown>> {
+): Promise<string> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylink, opts);
 
   // GET request the skylink
-  const response = await this.executeRequest({
+  let { data } = await this.executeRequest({
     ...opts,
     method: "get",
     url,
   });
 
-  return response.data;
+  if (typeof data !== "string") {
+    if (typeof data === "object" && data !== null) {
+      data = JSON.stringify(data);
+    } else {
+      throw new Error(
+        "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+      );
+    }
+  }
+
+  return data;
 }
 
 /**

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -116,7 +116,7 @@ describe("Upload and download integration tests", () => {
     const skylink = await client.uploadFile(file);
 
     const content = await client.getFileContent(skylink);
-    expect(content).toEqual(expect.any(String));
-    expect(content).toEqual(JSON.stringify(json));
+    expect(content).toEqual(expect.any(Object));
+    expect(content).toEqual(json);
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -96,15 +96,27 @@ describe("Registry end to end integration tests", () => {
 });
 
 describe("Upload and download integration tests", () => {
-  it("Should get file contents", async () => {
+  it("Should get plaintext file contents", async () => {
+    const data = "testing";
+
+    // Upload the data to acquire its skylink
+    const file = new File([data], dataKey, { type: "text/plain" });
+    const skylink = await client.uploadFile(file);
+
+    const content = await client.getFileContent(skylink);
+    expect(content).toEqual(expect.any(String));
+    expect(content).toEqual(data);
+  });
+
+  it("Should get JSON file contents", async () => {
     const json = { key: "testdownload" };
 
     // Upload the data to acquire its skylink
     const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
     const skylink = await client.uploadFile(file);
 
-    const data = await client.getFileContent(skylink);
-    expect(data).toEqual(expect.any(Object));
-    expect(data).toEqual(json);
+    const content = await client.getFileContent(skylink);
+    expect(content).toEqual(expect.any(String));
+    expect(content).toEqual(JSON.stringify(json));
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -15,6 +15,7 @@ const client = new SkynetClient(portalUrl);
 const registryUrl = `${portalUrl}/skynet/registry`;
 const registryLookupUrl = client.registry.getEntryUrl(publicKey, dataKey);
 const uploadUrl = `${portalUrl}/skynet/skyfile`;
+const skylinkUrl = client.getSkylinkUrl(skylink);
 
 const data = "43414241425f31447430464a73787173755f4a34546f644e4362434776744666315579735f3345677a4f6c546367";
 const revision = 11;
@@ -36,7 +37,7 @@ describe("getJSON", () => {
   it("should perform a lookup and skylink GET", async () => {
     // mock a successful registry lookup
     mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
-    mock.onGet(client.getSkylinkUrl(skylink)).reply(200, json);
+    mock.onGet(skylinkUrl).reply(200, json);
 
     const jsonReturned = await client.db.getJSON(publicKey, dataKey);
     expect(jsonReturned.data).toEqual(json);
@@ -49,6 +50,16 @@ describe("getJSON", () => {
     const { data, revision } = await client.db.getJSON(publicKey, dataKey);
     expect(data).toBeNull();
     expect(revision).toBeNull();
+  });
+
+  it("should throw if the returned file data is not JSON", async () => {
+    // mock a successful registry lookup
+    mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
+    mock.onGet(skylinkUrl).reply(200, "thisistext");
+
+    await expect(client.db.getJSON(publicKey, dataKey)).rejects.toThrowError(
+      `File data for the entry at data key '${dataKey}' is not JSON.`
+    );
   });
 });
 

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -49,15 +49,14 @@ export async function getJSON(
   }
 
   // Download the data in that Skylink.
-  // TODO: Replace with download request method.
   const skylink = entry.data;
-  const data = await this.getFileContent(skylink, opts);
+  const data = await this.getFileContent<Record<string, unknown>>(skylink, opts);
 
-  try {
-    return { data: JSON.parse(data), revision: entry.revision };
-  } catch (err) {
+  if (typeof data !== "object" || data === null) {
     throw new Error(`File data for the entry at data key '${dataKey}' is not JSON.`);
   }
+
+  return { data, revision: entry.revision };
 }
 
 /**

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -53,7 +53,11 @@ export async function getJSON(
   const skylink = entry.data;
   const data = await this.getFileContent(skylink, opts);
 
-  return { data, revision: entry.revision };
+  try {
+    return { data: JSON.parse(data), revision: entry.revision };
+  } catch (err) {
+    throw new Error(`File data for the entry at data key '${dataKey}' is not JSON.`);
+  }
 }
 
 /**


### PR DESCRIPTION
Previously, getFileContent would return a string for plaintext files and an
object for json files. It should only return a string -- in the case of json
files it will stringify the json.