### PR TITLE
[BREAKING] make upload request functions return full response

### DIFF
--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -101,9 +101,11 @@ describe("Upload and download integration tests", () => {
 
     // Upload the data to acquire its skylink
     const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
-    const skylink = await client.uploadFile(file);
+    const response = await client.uploadFileRequest(file);
+    expect(response.headers).toEqual(expect.any(Object));
+    expect(response.headers["content-type"]).toEqual("application/json; charset=utf-8");
 
-    const data = await client.getFileContent(skylink);
+    const data = await client.getFileContent(response.data.skylink);
     expect(data).toEqual(expect.any(Object));
     expect(data).toEqual(json);
   });

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -35,6 +35,9 @@ describe("uploadFile", () => {
   });
 
   it("should send register onUploadProgress callback if defined", async () => {
+    // Don't use default handler.
+    mock.resetHandlers();
+
     const newPortal = "https://my-portal.net";
     const url = `${newPortal}/skynet/skyfile`;
     const client = new SkynetClient(newPortal);
@@ -130,6 +133,16 @@ describe("uploadFile", () => {
     // @ts-expect-error we only check this use case in case someone ignores typescript typing
     await expect(client.uploadFile(file, { skykeyId: "test" })).rejects.toThrow();
   });
+
+  it("should throw if no skylink was returned", async () => {
+    // Don't use default handler.
+    mock.resetHandlers();
+    mock.onPost(url).replyOnce(200, {});
+
+    await expect(client.uploadFile(file)).rejects.toThrowError(
+      "Did not get expected 'skylink' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
+  });
 });
 
 describe("uploadDirectory", () => {
@@ -175,9 +188,11 @@ describe("uploadDirectory", () => {
   });
 
   it("should encode special characters in the URL", async () => {
+    // Don't use default handler.
+    mock.resetHandlers();
+
     const filename = "encoding?test";
     const url = `${portalUrl}/skynet/skyfile?filename=encoding%3Ftest`;
-    mock.resetHandlers();
     mock.onPost(url).replyOnce(200, { skylink });
 
     const data = await client.uploadDirectory(directory, filename);
@@ -185,5 +200,15 @@ describe("uploadDirectory", () => {
     expect(mock.history.post.length).toBe(1);
 
     expect(data).toEqual(sialink);
+  });
+
+  it("should throw if no skylink was returned", async () => {
+    // Don't use default handler.
+    mock.resetHandlers();
+    mock.onPost(url).replyOnce(200, {});
+
+    await expect(client.uploadDirectory(directory, filename)).rejects.toThrowError(
+      "Did not get expected 'skylink' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,5 +1,6 @@
 import { defaultOptions, uriSkynetPrefix, getFileMimeType, BaseCustomOptions } from "./utils";
 import { SkynetClient } from "./client";
+import { AxiosResponse } from "axios";
 
 /**
  * Custom upload options.
@@ -44,7 +45,13 @@ const defaultUploadOptions = {
 export async function uploadFile(this: SkynetClient, file: File, customOptions?: CustomUploadOptions): Promise<string> {
   const response = await this.uploadFileRequest(file, customOptions);
 
-  return `${uriSkynetPrefix}${response.skylink}`;
+  if (typeof response.data?.skylink !== "string") {
+    throw new Error(
+      "Did not get expected 'skylink' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
+  }
+
+  return `${uriSkynetPrefix}${response.data.skylink}`;
 }
 
 /**
@@ -60,7 +67,7 @@ export async function uploadFileRequest(
   this: SkynetClient,
   file: File,
   customOptions?: CustomUploadOptions
-): Promise<UploadRequestResponse> {
+): Promise<AxiosResponse> {
   const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
   const formData = new FormData();
 
@@ -71,13 +78,11 @@ export async function uploadFileRequest(
     formData.append(opts.portalFileFieldname, file);
   }
 
-  const { data } = await this.executeRequest({
+  return this.executeRequest({
     ...opts,
     method: "post",
     data: formData,
   });
-
-  return data;
 }
 
 /**
@@ -98,7 +103,13 @@ export async function uploadDirectory(
 ): Promise<string> {
   const response = await this.uploadDirectoryRequest(directory, filename, customOptions);
 
-  return `${uriSkynetPrefix}${response.skylink}`;
+  if (typeof response.data?.skylink !== "string") {
+    throw new Error(
+      "Did not get expected 'skylink' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
+  }
+
+  return `${uriSkynetPrefix}${response.data.skylink}`;
 }
 
 /**
@@ -116,7 +127,7 @@ export async function uploadDirectoryRequest(
   directory: Record<string, File>,
   filename: string,
   customOptions?: CustomUploadOptions
-): Promise<UploadRequestResponse> {
+): Promise<AxiosResponse> {
   const opts = { ...defaultUploadOptions, ...this.customOptions, ...customOptions };
   const formData = new FormData();
 
@@ -125,14 +136,12 @@ export async function uploadDirectoryRequest(
     formData.append(opts.portalDirectoryFileFieldname, file as File, path);
   });
 
-  const { data } = await this.executeRequest({
+  return this.executeRequest({
     ...opts,
     method: "post",
     data: formData,
     query: { filename },
   });
-
-  return data;
 }
 
 /**


### PR DESCRIPTION
The upload request functions were previously not that useful. The intended purpose of these functions was to get the full response so that e.g. headers can be examined. 