### PR TITLE
[BREAKING] Refactor getfilecontent and upload methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,8 @@ import {
   getHnsresUrl,
   getMetadata,
   getFileContent,
+  getFileContentHns,
+  getFileContentRequest,
   openFile,
   openFileHns,
   resolveHns,
@@ -77,6 +79,8 @@ export class SkynetClient {
   getHnsresUrl = getHnsresUrl;
   getMetadata = getMetadata;
   getFileContent = getFileContent;
+  getFileContentHns = getFileContentHns;
+  protected getFileContentRequest = getFileContentRequest;
   openFile = openFile;
   openFileHns = openFileHns;
   resolveHns = resolveHns;

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,11 +67,13 @@ export class SkynetClient {
 
   // Set methods (defined in other files).
 
+  // Upload
   uploadFile = uploadFile;
+  protected uploadFileRequest = uploadFileRequest;
   uploadDirectory = uploadDirectory;
-  uploadDirectoryRequest = uploadDirectoryRequest;
-  uploadFileRequest = uploadFileRequest;
+  protected uploadDirectoryRequest = uploadDirectoryRequest;
 
+  // Download
   downloadFile = downloadFile;
   downloadFileHns = downloadFileHns;
   getSkylinkUrl = getSkylinkUrl;

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -191,9 +191,9 @@ describe("getFileContent", () => {
       const skylinkUrl = client.getSkylinkUrl(input);
       mock.onGet(skylinkUrl).reply(200, skynetFileContents, headers);
 
-      const fileData = await client.getFileContent(input);
+      const { data } = await client.getFileContent(input);
 
-      expect(fileData).toEqual(skynetFileContents);
+      expect(data).toEqual(skynetFileContents);
     });
   });
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -193,8 +193,16 @@ describe("getFileContent", () => {
 
       const fileData = await client.getFileContent(input);
 
-      expect(fileData).toEqual(skynetFileContents);
+      expect(fileData).toEqual(JSON.stringify(skynetFileContents));
     });
+  });
+
+  it("should throw if data is not returned", async () => {
+    mock.onGet(expectedUrl).reply(200);
+
+    await expect(client.getFileContent(skylink)).rejects.toThrowError(
+      "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   });
 });
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -193,7 +193,7 @@ describe("getFileContent", () => {
 
       const fileData = await client.getFileContent(input);
 
-      expect(fileData).toEqual(JSON.stringify(skynetFileContents));
+      expect(fileData).toEqual(skynetFileContents);
     });
   });
 

--- a/src/download.test.ts
+++ b/src/download.test.ts
@@ -155,9 +155,9 @@ describe("getMetadata", () => {
       const skylinkUrl = client.getSkylinkUrl(fullSkylink);
       mock.onHead(skylinkUrl).reply(200, {}, headersFull);
 
-      const responseMetadata = await client.getMetadata(fullSkylink);
+      const { metadata } = await client.getMetadata(fullSkylink);
 
-      expect(responseMetadata).toEqual(skynetFileMetadata);
+      expect(metadata).toEqual(skynetFileMetadata);
     }
   );
 
@@ -169,9 +169,9 @@ describe("getMetadata", () => {
       const skylinkUrl = client.getSkylinkUrl(fullSkylink);
       mock.onHead(skylinkUrl).reply(200, {}, headersEmpty);
 
-      const responseMetadata = await client.getMetadata(fullSkylink);
+      const { metadata } = await client.getMetadata(fullSkylink);
 
-      expect(responseMetadata).toEqual({});
+      expect(metadata).toEqual({});
     }
   );
 });

--- a/src/download.ts
+++ b/src/download.ts
@@ -234,29 +234,25 @@ export async function getMetadata(
  * @returns - The content of the file.
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
-export async function getFileContent(
+export async function getFileContent<T = unknown>(
   this: SkynetClient,
   skylink: string,
   customOptions?: CustomDownloadOptions
-): Promise<string> {
+): Promise<T> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylink, opts);
 
   // GET request the skylink
-  let { data } = await this.executeRequest({
+  const { data } = await this.executeRequest({
     ...opts,
     method: "get",
     url,
   });
 
-  if (typeof data !== "string") {
-    if (typeof data === "object" && data !== null) {
-      data = JSON.stringify(data);
-    } else {
-      throw new Error(
-        "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
-      );
-    }
+  if (typeof data === "undefined") {
+    throw new Error(
+      "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   }
 
   return data;

--- a/src/download.ts
+++ b/src/download.ts
@@ -55,10 +55,12 @@ export type GetFileContentResponse<T = unknown> = {
 /**
  * The response for a get metadata request.
  *
+ * @property contentType - The type of the content.
  * @property metadata - The metadata in JSON format.
  * @property skylink - 46-character skylink.
  */
 export type GetMetadataResponse = {
+  contentType: string;
   metadata: Record<string, unknown>;
   skylink: string;
 };
@@ -284,10 +286,11 @@ export async function getMetadata(
     );
   }
 
+  const contentType = response.headers["content-type"] ?? "";
   const metadata = response.headers["skynet-file-metadata"] ? JSON.parse(response.headers["skynet-file-metadata"]) : {};
   const skylink = response.headers["skynet-skylink"] ? formatSkylink(response.headers["skynet-skylink"]) : "";
 
-  return { metadata, skylink };
+  return { contentType, metadata, skylink };
 }
 
 /**

--- a/src/download.ts
+++ b/src/download.ts
@@ -285,7 +285,7 @@ export async function getMetadata(
   }
 
   const metadata = response.headers["skynet-file-metadata"] ? JSON.parse(response.headers["skynet-file-metadata"]) : {};
-  const skylink = response.headers["skynet-skylink"] ?? "";
+  const skylink = response.headers["skynet-skylink"] ? formatSkylink(response.headers["skynet-skylink"]) : "";
 
   return { metadata, skylink };
 }
@@ -322,16 +322,16 @@ export async function getFileContent<T = unknown>(
  * @param this - SkynetClient
  * @param domain - Handshake domain.
  * @param [customOptions] - Additional settings that can optionally be set.
- * @param [customOptions.endpointPath="/"] - The relative URL path of the portal endpoint to contact.
+ * @param [customOptions.endpointPath="/hns"] - The relative URL path of the portal endpoint to contact.
  * @returns - An object containing the data of the file, the content-type, metadata, and the file's skylink.
  * @throws - Will throw if the domain does not contain a skylink.
  */
 export async function getFileContentHns<T = unknown>(
   this: SkynetClient,
   domain: string,
-  customOptions?: CustomDownloadOptions
+  customOptions?: CustomHnsDownloadOptions
 ): Promise<GetFileContentResponse<T>> {
-  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
+  const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions };
   const url = this.getHnsUrl(domain, opts);
 
   return this.getFileContentRequest<T>(url, opts);
@@ -343,7 +343,6 @@ export async function getFileContentHns<T = unknown>(
  * @param this - SkynetClient
  * @param url - URL.
  * @param [customOptions] - Additional settings that can optionally be set.
- * @param [customOptions.endpointPath="/"] - The relative URL path of the portal endpoint to contact.
  * @returns - An object containing the data of the file, the content-type, metadata, and the file's skylink.
  * @throws - Will throw if the request does not succeed or the response is missing data.
  */

--- a/src/download.ts
+++ b/src/download.ts
@@ -5,6 +5,7 @@ import {
   BaseCustomOptions,
   convertSkylinkToBase32,
   defaultOptions,
+  formatSkylink,
   makeUrl,
   parseSkylink,
   trimUriPrefix,
@@ -298,7 +299,7 @@ export async function getFileContent<T = unknown>(
   // TODO: Return null instead if header not found?
   const contentType = response.headers["content-type"] ?? "";
   const metadata = response.headers["skynet-file-metadata"] ? JSON.parse(response.headers["skynet-file-metadata"]) : {};
-  const skylink = response.headers["skynet-skylink"] ?? "";
+  const skylink = response.headers["skynet-skylink"] ? formatSkylink(response.headers["skynet-skylink"]) : "";
 
   return { data: response.data, contentType, metadata, skylink };
 }

--- a/src/download.ts
+++ b/src/download.ts
@@ -238,18 +238,28 @@ export async function getFileContent(
   this: SkynetClient,
   skylink: string,
   customOptions?: CustomDownloadOptions
-): Promise<Record<string, unknown>> {
+): Promise<string> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylink, opts);
 
   // GET request the skylink
-  const response = await this.executeRequest({
+  let { data } = await this.executeRequest({
     ...opts,
     method: "get",
     url,
   });
 
-  return response.data;
+  if (typeof data !== "string") {
+    if (typeof data === "object" && data !== null) {
+      data = JSON.stringify(data);
+    } else {
+      throw new Error(
+        "Did not get 'data' in response despite a successful request. Please try again and report this issue to the devs if it persists."
+      );
+    }
+  }
+
+  return data;
 }
 
 /**

--- a/src/download.ts
+++ b/src/download.ts
@@ -261,7 +261,7 @@ export async function getMetadata(
 }
 
 /**
- * Does a GET request of the skylink, returning the data property of the response.
+ * Gets the contents of the file at the given skylink.
  *
  * @param this - SkynetClient
  * @param skylinkStr - 46 character skylink.
@@ -277,6 +277,47 @@ export async function getFileContent<T = unknown>(
 ): Promise<GetFileContentResponse<T>> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
   const url = this.getSkylinkUrl(skylinkStr, opts);
+
+  return this.getFileContentRequest<T>(url, opts);
+}
+
+/**
+ * Gets the contents of the file at the given Handshake domain.
+ *
+ * @param this - SkynetClient
+ * @param domain - Handshake domain.
+ * @param [customOptions] - Additional settings that can optionally be set.
+ * @param [customOptions.endpointPath="/"] - The relative URL path of the portal endpoint to contact.
+ * @returns - An object containing the data of the file, the content-type, metadata, and the file's skylink.
+ * @throws - Will throw if the domain does not contain a skylink.
+ */
+export async function getFileContentHns<T = unknown>(
+  this: SkynetClient,
+  domain: string,
+  customOptions?: CustomDownloadOptions
+): Promise<GetFileContentResponse<T>> {
+  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
+  const url = this.getHnsUrl(domain, opts);
+
+  return this.getFileContentRequest<T>(url, opts);
+}
+
+/**
+ * Does a GET request of the skylink, returning the data property of the response.
+ *
+ * @param this - SkynetClient
+ * @param url - URL.
+ * @param [customOptions] - Additional settings that can optionally be set.
+ * @param [customOptions.endpointPath="/"] - The relative URL path of the portal endpoint to contact.
+ * @returns - An object containing the data of the file, the content-type, metadata, and the file's skylink.
+ * @throws - Will throw if the request does not succeed or the response is missing data.
+ */
+export async function getFileContentRequest<T = unknown>(
+  this: SkynetClient,
+  url: string,
+  customOptions?: CustomDownloadOptions
+): Promise<GetFileContentResponse<T>> {
+  const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
 
   // GET request the data at the skylink.
   const response = await this.executeRequest({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,8 @@ describe("SkynetClient", () => {
     // Download
     expect(client).toHaveProperty("downloadFile");
     expect(client).toHaveProperty("downloadFileHns");
+    expect(client).toHaveProperty("getFileContent");
+    expect(client).toHaveProperty("getFileContentHns");
     expect(client).toHaveProperty("getHnsUrl");
     expect(client).toHaveProperty("getHnsresUrl");
     expect(client).toHaveProperty("getSkylinkUrl");
@@ -17,9 +19,7 @@ describe("SkynetClient", () => {
 
     // Upload
     expect(client).toHaveProperty("uploadFile");
-    expect(client).toHaveProperty("uploadFileRequest");
     expect(client).toHaveProperty("uploadDirectory");
-    expect(client).toHaveProperty("uploadDirectoryRequest");
 
     // SkyDB
     expect(client).toHaveProperty("db");

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -116,7 +116,7 @@ describe("Upload and download integration tests", () => {
     const skylink = await client.uploadFile(file);
 
     const content = await client.getFileContent(skylink);
-    expect(content).toEqual(expect.any(String));
-    expect(content).toEqual(JSON.stringify(json));
+    expect(content).toEqual(expect.any(Object));
+    expect(content).toEqual(json);
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -110,7 +110,7 @@ describe("Upload and download integration tests", () => {
 
     // Upload the data to acquire its skylink
     const file = new File([fileData], dataKey, { type: "text/plain" });
-    const skylink = await client.uploadFile(file);
+    const { skylink } = await client.uploadFile(file);
 
     const { data } = await client.getFileContent(skylink);
     expect(data).toEqual(expect.any(String));
@@ -122,7 +122,7 @@ describe("Upload and download integration tests", () => {
 
     // Upload the data to acquire its skylink
     const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
-    const skylink = await client.uploadFile(file);
+    const { skylink } = await client.uploadFile(file);
 
     const { data } = await client.getFileContent(skylink);
     expect(data).toEqual(expect.any(Object));

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -97,15 +97,15 @@ describe("Registry end to end integration tests", () => {
 
 describe("Upload and download integration tests", () => {
   it("Should get plaintext file contents", async () => {
-    const data = "testing";
+    const fileData = "testing";
 
     // Upload the data to acquire its skylink
-    const file = new File([data], dataKey, { type: "text/plain" });
+    const file = new File([fileData], dataKey, { type: "text/plain" });
     const skylink = await client.uploadFile(file);
 
-    const content = await client.getFileContent(skylink);
-    expect(content).toEqual(expect.any(String));
-    expect(content).toEqual(data);
+    const { data } = await client.getFileContent(skylink);
+    expect(data).toEqual(expect.any(String));
+    expect(data).toEqual(data);
   });
 
   it("Should get JSON file contents", async () => {
@@ -115,8 +115,8 @@ describe("Upload and download integration tests", () => {
     const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
     const skylink = await client.uploadFile(file);
 
-    const content = await client.getFileContent(skylink);
-    expect(content).toEqual(expect.any(Object));
-    expect(content).toEqual(json);
+    const { data } = await client.getFileContent(skylink);
+    expect(data).toEqual(expect.any(Object));
+    expect(data).toEqual(json);
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -96,15 +96,27 @@ describe("Registry end to end integration tests", () => {
 });
 
 describe("Upload and download integration tests", () => {
-  it("Should get file contents", async () => {
+  it("Should get plaintext file contents", async () => {
+    const data = "testing";
+
+    // Upload the data to acquire its skylink
+    const file = new File([data], dataKey, { type: "text/plain" });
+    const skylink = await client.uploadFile(file);
+
+    const content = await client.getFileContent(skylink);
+    expect(content).toEqual(expect.any(String));
+    expect(content).toEqual(data);
+  });
+
+  it("Should get JSON file contents", async () => {
     const json = { key: "testdownload" };
 
     // Upload the data to acquire its skylink
     const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
     const skylink = await client.uploadFile(file);
 
-    const data = await client.getFileContent(skylink);
-    expect(data).toEqual(expect.any(Object));
-    expect(data).toEqual(json);
+    const content = await client.getFileContent(skylink);
+    expect(content).toEqual(expect.any(String));
+    expect(content).toEqual(JSON.stringify(json));
   });
 });

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -37,7 +37,7 @@ describe("getJSON", () => {
   it("should perform a lookup and skylink GET", async () => {
     // mock a successful registry lookup
     mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
-    mock.onGet(skylinkUrl).reply(200, json);
+    mock.onGet(skylinkUrl).reply(200, json, {});
 
     const jsonReturned = await client.db.getJSON(publicKey, dataKey);
     expect(jsonReturned.data).toEqual(json);
@@ -55,7 +55,7 @@ describe("getJSON", () => {
   it("should throw if the returned file data is not JSON", async () => {
     // mock a successful registry lookup
     mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
-    mock.onGet(skylinkUrl).reply(200, "thisistext");
+    mock.onGet(skylinkUrl).reply(200, "thisistext", {});
 
     await expect(client.db.getJSON(publicKey, dataKey)).rejects.toThrowError(
       `File data for the entry at data key '${dataKey}' is not JSON.`

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -9,6 +9,8 @@ const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const dataKey = "app";
 const skylink = "CABAB_1Dt0FJsxqsu_J4TodNCbCGvtFf1Uys_3EgzOlTcg";
 const json = { data: "thisistext" };
+const merkleroot = "QAf9Q7dBSbMarLvyeE6HTQmwhr7RX9VMrP9xIMzpU3I";
+const bitfield = 2048;
 
 const portalUrl = defaultSkynetPortalUrl;
 const client = new SkynetClient(portalUrl);
@@ -69,12 +71,11 @@ describe("setJSON", () => {
   beforeEach(() => {
     mock = new MockAdapter(axios);
     mock.resetHistory();
+    // mock a successful upload
+    mock.onPost(uploadUrl).reply(200, { skylink, merkleroot, bitfield });
   });
 
   it("should perform an upload, lookup and registry update", async () => {
-    // mock a successful upload
-    mock.onPost(uploadUrl).reply(200, { skylink });
-
     // mock a successful registry lookup
     mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
 
@@ -94,9 +95,6 @@ describe("setJSON", () => {
   });
 
   it("should use the revision if it is passed in", async () => {
-    // mock a successful upload
-    mock.onPost(uploadUrl).reply(200, { skylink });
-
     // mock a successful registry update
     mock.onPost(registryUrl).reply(204);
 
@@ -114,9 +112,6 @@ describe("setJSON", () => {
   });
 
   it("should use a revision number of 0 if the lookup failed", async () => {
-    // mock a successful upload
-    mock.onPost(uploadUrl).reply(200, { skylink });
-
     mock.onGet(registryLookupUrl).reply(404);
 
     // mock a successful registry update
@@ -135,9 +130,6 @@ describe("setJSON", () => {
   });
 
   it("should fail if the entry has the maximum allowed revision", async () => {
-    // mock a successful upload
-    mock.onPost(uploadUrl).reply(200, { skylink });
-
     // mock a successful registry lookup
     const entryData = {
       data,

--- a/src/skydb.test.ts
+++ b/src/skydb.test.ts
@@ -15,6 +15,7 @@ const client = new SkynetClient(portalUrl);
 const registryUrl = `${portalUrl}/skynet/registry`;
 const registryLookupUrl = client.registry.getEntryUrl(publicKey, dataKey);
 const uploadUrl = `${portalUrl}/skynet/skyfile`;
+const skylinkUrl = client.getSkylinkUrl(skylink);
 
 const data = "43414241425f31447430464a73787173755f4a34546f644e4362434776744666315579735f3345677a4f6c546367";
 const revision = 11;
@@ -36,7 +37,7 @@ describe("getJSON", () => {
   it("should perform a lookup and skylink GET", async () => {
     // mock a successful registry lookup
     mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
-    mock.onGet(client.getSkylinkUrl(skylink)).reply(200, json);
+    mock.onGet(skylinkUrl).reply(200, json);
 
     const jsonReturned = await client.db.getJSON(publicKey, dataKey);
     expect(jsonReturned.data).toEqual(json);
@@ -49,6 +50,16 @@ describe("getJSON", () => {
     const { data, revision } = await client.db.getJSON(publicKey, dataKey);
     expect(data).toBeNull();
     expect(revision).toBeNull();
+  });
+
+  it("should throw if the returned file data is not JSON", async () => {
+    // mock a successful registry lookup
+    mock.onGet(registryLookupUrl).reply(200, JSON.stringify(entryData));
+    mock.onGet(skylinkUrl).reply(200, "thisistext");
+
+    await expect(client.db.getJSON(publicKey, dataKey)).rejects.toThrowError(
+      `File data for the entry at data key '${dataKey}' is not JSON.`
+    );
   });
 });
 

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -49,15 +49,14 @@ export async function getJSON(
   }
 
   // Download the data in that Skylink.
-  // TODO: Replace with download request method.
   const skylink = entry.data;
-  const data = await this.getFileContent(skylink, opts);
+  const data = await this.getFileContent<Record<string, unknown>>(skylink, opts);
 
-  try {
-    return { data: JSON.parse(data), revision: entry.revision };
-  } catch (err) {
+  if (typeof data !== "object" || data === null) {
     throw new Error(`File data for the entry at data key '${dataKey}' is not JSON.`);
   }
+
+  return { data, revision: entry.revision };
 }
 
 /**

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -53,7 +53,11 @@ export async function getJSON(
   const skylink = entry.data;
   const data = await this.getFileContent(skylink, opts);
 
-  return { data, revision: entry.revision };
+  try {
+    return { data: JSON.parse(data), revision: entry.revision };
+  } catch (err) {
+    throw new Error(`File data for the entry at data key '${dataKey}' is not JSON.`);
+  }
 }
 
 /**

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -42,7 +42,7 @@ export async function getJSON(
     ...customOptions,
   };
 
-  // lookup the registry entry
+  // Lookup the registry entry.
   const { entry }: { entry: RegistryEntry } = await this.registry.getEntry(publicKey, dataKey, opts);
   if (entry === null) {
     return { data: null, revision: null };
@@ -116,6 +116,6 @@ export async function setJSON(
     revision,
   };
 
-  // update the registry
+  // Update the registry.
   await this.registry.setEntry(privateKey, entry);
 }

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -129,7 +129,7 @@ export async function setJSON(
 
   // Upload the data to acquire its skylink.
   const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
-  const skylink = await this.uploadFile(file, opts);
+  const { skylink } = await this.uploadFile(file, opts);
 
   // build the registry value
   const entry: RegistryEntry = {

--- a/src/skydb.ts
+++ b/src/skydb.ts
@@ -50,7 +50,7 @@ export async function getJSON(
 
   // Download the data in that Skylink.
   const skylink = entry.data;
-  const data = await this.getFileContent<Record<string, unknown>>(skylink, opts);
+  const { data } = await this.getFileContent<Record<string, unknown>>(skylink, opts);
 
   if (typeof data !== "object" || data === null) {
     throw new Error(`File data for the entry at data key '${dataKey}' is not JSON.`);

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -8,6 +8,9 @@ const portalUrl = defaultSkynetPortalUrl;
 const client = new SkynetClient(portalUrl);
 const skylink = "XABvi7JtJbQSMAcDwnUnmp2FKDPjg8_tTTFP4BwMSxVdEg";
 const sialink = `${uriSkynetPrefix}${skylink}`;
+const merkleroot = "QAf9Q7dBSbMarLvyeE6HTQmwhr7RX9VMrP9xIMzpU3I";
+const bitfield = 2048;
+const data = { skylink, merkleroot, bitfield };
 
 describe("uploadFile", () => {
   const url = `${portalUrl}/skynet/skyfile`;
@@ -19,7 +22,7 @@ describe("uploadFile", () => {
 
   beforeEach(() => {
     mock = new MockAdapter(axios);
-    mock.onPost(url).replyOnce(200, { skylink });
+    mock.onPost(url).replyOnce(200, data);
     mock.resetHistory();
   });
 
@@ -31,7 +34,7 @@ describe("uploadFile", () => {
 
     await compareFormData(request.data, [["file", "foo", filename]]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("should send register onUploadProgress callback if defined", async () => {
@@ -40,9 +43,9 @@ describe("uploadFile", () => {
     const client = new SkynetClient(newPortal);
 
     // Use replyOnce to catch a single request with the new URL.
-    mock.onPost(url).replyOnce(200, { skylink });
+    mock.onPost(url).replyOnce(200, data);
 
-    const data = await client.uploadFile(file, { onUploadProgress: jest.fn() });
+    const response = await client.uploadFile(file, { onUploadProgress: jest.fn() });
 
     expect(mock.history.post.length).toBe(1);
     const request = mock.history.post[0];
@@ -50,7 +53,7 @@ describe("uploadFile", () => {
     expect(request.onUploadProgress).toEqual(expect.any(Function));
     await compareFormData(request.data, [["file", "foo", filename]]);
 
-    expect(data).toEqual(sialink);
+    expect(response.skylink).toEqual(sialink);
   });
 
   it("should use custom filename if provided", async () => {
@@ -61,7 +64,7 @@ describe("uploadFile", () => {
 
     await compareFormData(request.data, [["file", "foo", "testname"]]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("should send base-64 authentication password if provided", async () => {
@@ -73,7 +76,7 @@ describe("uploadFile", () => {
     expect(request.auth).toEqual({ username: "", password: "foobar" });
     await compareFormData(request.data, [["file", "foo", filename]]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("should send portal's custom user agent if defined", async () => {
@@ -89,7 +92,7 @@ describe("uploadFile", () => {
     expect(request.headers["Content-Type"]).toEqual("application/x-www-form-urlencoded");
     await compareFormData(request.data, [["file", "foo", filename]]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("Should use user agent set in options passed to function", async () => {
@@ -105,7 +108,7 @@ describe("uploadFile", () => {
     expect(request.headers["Content-Type"]).toEqual("application/x-www-form-urlencoded");
     await compareFormData(request.data, [["file", "foo", filename]]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("Should send custom query parameters if provided", async () => {
@@ -115,12 +118,12 @@ describe("uploadFile", () => {
     const url = `${portalUrl}/skynet/skyfile`;
     const client = new SkynetClient(portalUrl, { customUserAgent: "Sia-Agent" });
 
-    mock.onPost(`${url}?file=test`).replyOnce(200, { skylink });
+    mock.onPost(`${url}?file=test`).replyOnce(200, data);
 
     const query = { file: "test" };
-    const data = await client.uploadFile(file, { query });
+    const response = await client.uploadFile(file, { query });
 
-    expect(data).toEqual(sialink);
+    expect(response.skylink).toEqual(sialink);
   });
 
   it("Trying to upload with a skykey should throw an error", async () => {
@@ -135,7 +138,9 @@ describe("uploadFile", () => {
     mock.resetHandlers();
     mock.onPost(url).replyOnce(200, {});
 
-    await expect(client.uploadFile(file)).rejects.toThrowError("Did not get expected skylink response");
+    await expect(client.uploadFile(file)).rejects.toThrowError(
+      "Did not get a complete upload response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
   });
 });
 
@@ -151,7 +156,7 @@ describe("uploadDirectory", () => {
 
   beforeEach(() => {
     mock = new MockAdapter(axios);
-    mock.onPost(url).replyOnce(200, { skylink });
+    mock.onPost(url).replyOnce(200, data);
     mock.resetHistory();
   });
 
@@ -167,7 +172,7 @@ describe("uploadDirectory", () => {
       ["files[]", "foo3", "i-am-not/me-neither/file3.jpeg"],
     ]);
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("should send register onUploadProgress callback if defined", async () => {
@@ -178,19 +183,19 @@ describe("uploadDirectory", () => {
 
     expect(request.onUploadProgress).toEqual(expect.any(Function));
 
-    expect(data).toEqual(sialink);
+    expect(data.skylink).toEqual(sialink);
   });
 
   it("should encode special characters in the URL", async () => {
     const filename = "encoding?test";
     const url = `${portalUrl}/skynet/skyfile?filename=encoding%3Ftest`;
     mock.resetHandlers();
-    mock.onPost(url).replyOnce(200, { skylink });
+    mock.onPost(url).replyOnce(200, data);
 
-    const data = await client.uploadDirectory(directory, filename);
+    const response = await client.uploadDirectory(directory, filename);
 
     expect(mock.history.post.length).toBe(1);
 
-    expect(data).toEqual(sialink);
+    expect(response.skylink).toEqual(sialink);
   });
 });

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -198,4 +198,13 @@ describe("uploadDirectory", () => {
 
     expect(response.skylink).toEqual(sialink);
   });
+
+  it("should throw if a skylink was not returned", async () => {
+    mock.resetHandlers();
+    mock.onPost(url).replyOnce(200, {});
+
+    await expect(client.uploadDirectory(directory, filename)).rejects.toThrowError(
+      "Did not get a complete upload response despite a successful request. Please try again and report this issue to the devs if it persists."
+    );
+  });
 });

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,4 +1,4 @@
-import { defaultOptions, uriSkynetPrefix, getFileMimeType, BaseCustomOptions } from "./utils";
+import { defaultOptions, uriSkynetPrefix, getFileMimeType, BaseCustomOptions, formatSkylink } from "./utils";
 import { SkynetClient } from "./client";
 
 /**
@@ -42,9 +42,9 @@ const defaultUploadOptions = {
  * @returns - The returned skylink.
  */
 export async function uploadFile(this: SkynetClient, file: File, customOptions?: CustomUploadOptions): Promise<string> {
-  const response = await this.uploadFileRequest(file, customOptions);
+  const data = await this.uploadFileRequest(file, customOptions);
 
-  return `${uriSkynetPrefix}${response.skylink}`;
+  return formatSkylink(data.skylink);
 }
 
 /**
@@ -98,7 +98,7 @@ export async function uploadDirectory(
 ): Promise<string> {
   const response = await this.uploadDirectoryRequest(directory, filename, customOptions);
 
-  return `${uriSkynetPrefix}${response.skylink}`;
+  return formatSkylink(response.skylink);
 }
 
 /**

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -3,6 +3,7 @@ import {
   assertUint64,
   convertSkylinkToBase32,
   defaultSkynetPortalUrl,
+  formatSkylink,
   getFileMimeType,
   getRelativeFilePath,
   getRootDirectory,
@@ -75,6 +76,19 @@ describe("convertSkylinkToBase32", () => {
     const encoded = convertSkylinkToBase32(skylink);
 
     expect(encoded).toEqual(skylinkBase32);
+  });
+});
+
+describe("formatSkylink", () => {
+  it("should ensure the skylink starts with the prefix", () => {
+    const prefixedSkylink = `sia:${skylink}`;
+
+    expect(formatSkylink(skylink)).toEqual(prefixedSkylink);
+    expect(formatSkylink(prefixedSkylink)).toEqual(prefixedSkylink);
+  });
+
+  it("should not prepend a prefix for the empty string", () => {
+    expect(formatSkylink("")).toEqual("");
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,6 +140,9 @@ export function defaultPortalUrl(): string {
  * @returns - The formatted skylink.
  */
 export function formatSkylink(skylink: string): string {
+  if (skylink == "") {
+    return skylink;
+  }
   if (!skylink.startsWith(uriSkynetPrefix)) {
     skylink = `${uriSkynetPrefix}${skylink}`;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,6 +128,19 @@ export function defaultPortalUrl(): string {
 }
 
 /**
+ * Formats the skylink by adding the sia: prefix.
+ *
+ * @param skylink - The skylink.
+ * @returns - The formatted skylink.
+ */
+export function formatSkylink(skylink: string): string {
+  if (!skylink.startsWith(uriSkynetPrefix)) {
+    skylink = `${uriSkynetPrefix}${skylink}`;
+  }
+  return skylink;
+}
+
+/**
  * Gets the path for the file.
  *
  * @param file - The file.


### PR DESCRIPTION
- [BREAKING] Upload methods return object
- [BREAKING] Remove upload request
- [BREAKING] Make getMetadata return object containing metadata and skylink
- Return object containing contentType, metadata, skylink from getFileContent
- getFileContent returns a skylink prefixed with sia:
- Add getFileContentHns