### PR TITLE
Run integration tests daily

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,7 +19,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Daily CI
+      - name: Use Node.js
         uses: actions/setup-node@v1
-      - run: yarn
-      - run: SKYNET_JS_INTEGRATION_TEST_SERVER="https://${{ matrix.server }}.siasky.net" yarn run jest src/integration.test.ts
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Integration test on server
+        run: yarn run jest src/integration.test.ts
+        env:
+          SKYNET_JS_INTEGRATION_TEST_SERVER: "https://${{ matrix.server }}.siasky.net"

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Daily CI
         uses: actions/setup-node@v1
       - run: yarn
-      - run: SKYNET_JS_INTEGRATION_TEST_SERVER="https://${{ matrix.server }}.siasky.net" yarn test src/integration.test.ts
+      - run: SKYNET_JS_INTEGRATION_TEST_SERVER="https://${{ matrix.server }}.siasky.net" yarn run jest src/integration.test.ts

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,17 @@
+# This workflow will run integrations tests daily at midnight.
+
+name: Daily CI
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Daily CI
+        uses: actions/setup-node@v1
+      - run: ./test-all-servers

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,9 +3,6 @@
 name: Daily CI
 
 on:
-  # JUST FOR TESTING THE WORKFLOW
-  pull_request:
-    branches: [master]
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -3,15 +3,23 @@
 name: Daily CI
 
 on:
+  # JUST FOR TESTING THE WORKFLOW
+  pull_request:
+    branches: [master]
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
   test:
+    name: Daily Server Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        server: [eu-ger-1, eu-ger-2, eu-fin-1, us-or-1, us-or-2, us-pa-1, us-pa-2, us-va-1]
 
     steps:
       - uses: actions/checkout@v2
       - name: Daily CI
         uses: actions/setup-node@v1
-      - run: ./test-all-servers
+      - run: yarn
+      - run: SKYNET_JS_INTEGRATION_TEST_SERVER="https://${{ matrix.server }}.siasky.net" yarn test src/integration.test.ts

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -18,6 +18,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Use Node.js
         uses: actions/setup-node@v1
+        with:
+          node-version: "14"
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "not OperaMini all"
   ],
   "scripts": {
-    "test": "jest --coverage --coverageDirectory ../coverage",
     "build": "rimraf dist && babel src --out-dir dist --extensions .ts --ignore src/**/*.test.ts && tsc --project tsconfig.build.json",
     "lint:eslint": "eslint --ext .ts utils src --max-warnings 0",
     "lint:tsc": "tsc",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "test": "jest --coverage --coverageDirectory ../coverage"
   },
   "jest": {
     "testTimeout": 60000,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -2,7 +2,7 @@ import { genKeyPairAndSeed, SkynetClient } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 import { MAX_REVISION } from "./utils";
 
-let portal = "https://siasky.dev";
+let portal = "https://siasky.net";
 
 // To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn test src/integration.test.ts
 const testServer = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER;

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -2,136 +2,132 @@ import { genKeyPairAndSeed, SkynetClient } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 import { MAX_REVISION } from "./utils";
 
-let portal = "https://siasky.net";
-
 // To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn test src/integration.test.ts
-const testServer = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER;
-if (testServer) {
-  portal = testServer;
-}
-console.log(`Running integration tests with portal ${portal}`);
+const portal = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER || "https://siasky.net";
 const client = new SkynetClient(portal);
 
 const dataKey = "HelloWorld";
 
-describe("SkyDB end to end integration tests", () => {
-  it("Should return null for an inexistent entry", async () => {
-    const { publicKey } = genKeyPairAndSeed();
+describe(`Integration test for portal ${portal}`, () => {
+  describe("SkyDB end to end integration tests", () => {
+    it("Should return null for an inexistent entry", async () => {
+      const { publicKey } = genKeyPairAndSeed();
 
-    // Try getting an inexistent entry.
-    const { data, revision } = await client.db.getJSON(publicKey, "foo");
-    expect(data).toBeNull();
-    expect(revision).toBeNull();
+      // Try getting an inexistent entry.
+      const { data, revision } = await client.db.getJSON(publicKey, "foo");
+      expect(data).toBeNull();
+      expect(revision).toBeNull();
+    });
+
+    it("Should set and get new entries", async () => {
+      const { publicKey, privateKey } = genKeyPairAndSeed();
+      const json = { data: "thisistext" };
+
+      // Set the file in the SkyDB.
+      await client.db.setJSON(privateKey, dataKey, json);
+
+      // get the file in the SkyDB
+      const { data, revision } = await client.db.getJSON(publicKey, dataKey);
+      expect(data).toEqual(json);
+      // Revision should be 0.
+      expect(revision).toEqual(BigInt(0));
+    });
+
+    it("Should set and get entries with the revision at the max allowed", async () => {
+      const { publicKey, privateKey } = genKeyPairAndSeed();
+      const json = { data: "testnumber2" };
+
+      await client.db.setJSON(privateKey, dataKey, json, MAX_REVISION);
+
+      const actual = await client.db.getJSON(publicKey, dataKey);
+      expect(actual.data).toEqual(json);
+      expect(actual.revision).toEqual(MAX_REVISION);
+    });
+
+    it("Try setting the revision higher than the uint64 max", async () => {
+      const { privateKey } = genKeyPairAndSeed();
+      const json = { data: "testnumber3" };
+      const largeint = MAX_REVISION + BigInt(1);
+
+      await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrowError(
+        "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"
+      );
+    });
   });
 
-  it("Should set and get new entries", async () => {
-    const { publicKey, privateKey } = genKeyPairAndSeed();
-    const json = { data: "thisistext" };
+  describe("Registry end to end integration tests", () => {
+    it("Should return null for an inexistent entry", async () => {
+      const { publicKey } = genKeyPairAndSeed();
 
-    // Set the file in the SkyDB.
-    await client.db.setJSON(privateKey, dataKey, json);
+      // Try getting an inexistant entry.
+      const { entry, signature } = await client.registry.getEntry(publicKey, "foo");
 
-    // get the file in the SkyDB
-    const { data, revision } = await client.db.getJSON(publicKey, dataKey);
-    expect(data).toEqual(json);
-    // Revision should be 0.
-    expect(revision).toEqual(BigInt(0));
+      expect(entry).toBeNull();
+      expect(signature).toBeNull();
+    });
+
+    it("Should set and get entries correctly", async () => {
+      const { publicKey, privateKey } = genKeyPairAndSeed();
+
+      const entry = {
+        datakey: dataKey,
+        data: "foo",
+        revision: BigInt(0),
+      };
+
+      await client.registry.setEntry(privateKey, entry);
+
+      const { entry: returnedEntry } = await client.registry.getEntry(publicKey, dataKey);
+
+      expect(returnedEntry).toEqual(entry);
+    });
+
+    it("setEntry should not be affected by timeout parameter", async () => {
+      const { publicKey, privateKey } = genKeyPairAndSeed();
+
+      const entry = {
+        datakey: dataKey,
+        data: "bar",
+        revision: BigInt(0),
+      };
+
+      // Use a timeout of 0 (invalid, but should be ignored).
+      await client.registry.setEntry(privateKey, entry, { timeout: 0 });
+      const { entry: returnedEntry } = await client.registry.getEntry(publicKey, dataKey);
+      expect(returnedEntry).toEqual(entry);
+
+      entry.revision = BigInt(1);
+
+      // Use a timeout of 301 (invalid, but should be ignored).
+      await client.registry.setEntry(privateKey, entry, { timeout: MAX_GET_ENTRY_TIMEOUT + 1 });
+      const { entry: returnedEntry2 } = await client.registry.getEntry(publicKey, dataKey);
+      expect(returnedEntry2).toEqual(entry);
+    });
   });
 
-  it("Should set and get entries with the revision at the max allowed", async () => {
-    const { publicKey, privateKey } = genKeyPairAndSeed();
-    const json = { data: "testnumber2" };
+  describe("Upload and download integration tests", () => {
+    it("Should get plaintext file contents", async () => {
+      const fileData = "testing";
 
-    await client.db.setJSON(privateKey, dataKey, json, MAX_REVISION);
+      // Upload the data to acquire its skylink
+      const file = new File([fileData], dataKey, { type: "text/plain" });
+      const { skylink } = await client.uploadFile(file);
 
-    const actual = await client.db.getJSON(publicKey, dataKey);
-    expect(actual.data).toEqual(json);
-    expect(actual.revision).toEqual(MAX_REVISION);
-  });
+      const { data } = await client.getFileContent(skylink);
+      expect(data).toEqual(expect.any(String));
+      expect(data).toEqual(data);
+    });
 
-  it("Try setting the revision higher than the uint64 max", async () => {
-    const { privateKey } = genKeyPairAndSeed();
-    const json = { data: "testnumber3" };
-    const largeint = MAX_REVISION + BigInt(1);
+    it("Should get JSON file contents", async () => {
+      const json = { key: "testdownload" };
 
-    await expect(client.db.setJSON(privateKey, dataKey, json, largeint)).rejects.toThrowError(
-      "Argument 18446744073709551616 does not fit in a 64-bit unsigned integer; exceeds 2^64-1"
-    );
-  });
-});
+      // Upload the data to acquire its skylink
+      const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
+      const { skylink } = await client.uploadFile(file);
 
-describe("Registry end to end integration tests", () => {
-  it("Should return null for an inexistent entry", async () => {
-    const { publicKey } = genKeyPairAndSeed();
-
-    // Try getting an inexistant entry.
-    const { entry, signature } = await client.registry.getEntry(publicKey, "foo");
-
-    expect(entry).toBeNull();
-    expect(signature).toBeNull();
-  });
-
-  it("Should set and get entries correctly", async () => {
-    const { publicKey, privateKey } = genKeyPairAndSeed();
-
-    const entry = {
-      datakey: dataKey,
-      data: "foo",
-      revision: BigInt(0),
-    };
-
-    await client.registry.setEntry(privateKey, entry);
-
-    const { entry: returnedEntry } = await client.registry.getEntry(publicKey, dataKey);
-
-    expect(returnedEntry).toEqual(entry);
-  });
-
-  it("setEntry should not be affected by timeout parameter", async () => {
-    const { publicKey, privateKey } = genKeyPairAndSeed();
-
-    const entry = {
-      datakey: dataKey,
-      data: "bar",
-      revision: BigInt(0),
-    };
-
-    // Use a timeout of 0 (invalid, but should be ignored).
-    await client.registry.setEntry(privateKey, entry, { timeout: 0 });
-    const { entry: returnedEntry } = await client.registry.getEntry(publicKey, dataKey);
-    expect(returnedEntry).toEqual(entry);
-
-    entry.revision = BigInt(1);
-
-    // Use a timeout of 301 (invalid, but should be ignored).
-    await client.registry.setEntry(privateKey, entry, { timeout: MAX_GET_ENTRY_TIMEOUT + 1 });
-    const { entry: returnedEntry2 } = await client.registry.getEntry(publicKey, dataKey);
-    expect(returnedEntry2).toEqual(entry);
-  });
-});
-
-describe("Upload and download integration tests", () => {
-  it("Should get plaintext file contents", async () => {
-    const fileData = "testing";
-
-    // Upload the data to acquire its skylink
-    const file = new File([fileData], dataKey, { type: "text/plain" });
-    const { skylink } = await client.uploadFile(file);
-
-    const { data } = await client.getFileContent(skylink);
-    expect(data).toEqual(expect.any(String));
-    expect(data).toEqual(data);
-  });
-
-  it("Should get JSON file contents", async () => {
-    const json = { key: "testdownload" };
-
-    // Upload the data to acquire its skylink
-    const file = new File([JSON.stringify(json)], dataKey, { type: "application/json" });
-    const { skylink } = await client.uploadFile(file);
-
-    const { data } = await client.getFileContent(skylink);
-    expect(data).toEqual(expect.any(Object));
-    expect(data).toEqual(json);
+      const { data } = await client.getFileContent(skylink);
+      expect(data).toEqual(expect.any(Object));
+      expect(data).toEqual(json);
+    });
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -2,12 +2,18 @@ import { genKeyPairAndSeed, SkynetClient } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 import { MAX_REVISION } from "./utils";
 
-// TODO: Use siasky.dev when available.
-const client = new SkynetClient("https://siasky.net");
+let portal = "https://siasky.net";
+
+// To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=eu-fin-1 yarn test src/integration.test.ts
+const testServer = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER;
+if (testServer) {
+  portal = `https://${testServer}.siasky.net`;
+}
+console.log(`Running integration tests with portal ${portal}`);
+const client = new SkynetClient(portal);
 
 const dataKey = "HelloWorld";
 
-// Used to verify end-to-end flow.
 describe("SkyDB end to end integration tests", () => {
   it("Should return null for an inexistent entry", async () => {
     const { publicKey } = genKeyPairAndSeed();

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -2,12 +2,12 @@ import { genKeyPairAndSeed, SkynetClient } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
 import { MAX_REVISION } from "./utils";
 
-let portal = "https://siasky.net";
+let portal = "https://siasky.dev";
 
-// To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=eu-fin-1 yarn test src/integration.test.ts
+// To test a specific server, e.g. SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn test src/integration.test.ts
 const testServer = process.env.SKYNET_JS_INTEGRATION_TEST_SERVER;
 if (testServer) {
-  portal = `https://${testServer}.siasky.net`;
+  portal = testServer;
 }
 console.log(`Running integration tests with portal ${portal}`);
 const client = new SkynetClient(portal);

--- a/test-all-servers
+++ b/test-all-servers
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# declare an array with all servers
+array=( eu-ger-1 eu-ger-2 eu-fin-1 us-or-1 us-or-2 us-pa-1 us-pa-2 us-va-1 )
+
+for i in "${array[@]}"
+do
+	SKYNET_JS_INTEGRATION_TEST_SERVER=$i yarn test src/integration.test.ts
+done

--- a/test-all-servers
+++ b/test-all-servers
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# declare an array with all servers
-array=( eu-ger-1 eu-ger-2 eu-fin-1 us-or-1 us-or-2 us-pa-1 us-pa-2 us-va-1 )
-
-for SERVER in "${array[@]}"
-do
-	SKYNET_JS_INTEGRATION_TEST_SERVER="https://$SERVER.siasky.net" yarn test src/integration.test.ts
-done

--- a/test-all-servers
+++ b/test-all-servers
@@ -3,7 +3,7 @@
 # declare an array with all servers
 array=( eu-ger-1 eu-ger-2 eu-fin-1 us-or-1 us-or-2 us-pa-1 us-pa-2 us-va-1 )
 
-for i in "${array[@]}"
+for SERVER in "${array[@]}"
 do
-	SKYNET_JS_INTEGRATION_TEST_SERVER=$i yarn test src/integration.test.ts
+	SKYNET_JS_INTEGRATION_TEST_SERVER="https://$SERVER.siasky.net" yarn test src/integration.test.ts
 done


### PR DESCRIPTION
1. The daily run will test against all `*.siasky.net` servers
2. ~~The PR CI pipeline will use `siasky.dev` instead of `siasky.net`~~ Use `siasky.net` since dev has a broken registry.
3. Individual servers can be tested by e.g. `SKYNET_JS_INTEGRATION_TEST_SERVER=https://eu-fin-1.siasky.net yarn run jest src/integration.test.ts`

Example successful run:
https://github.com/NebulousLabs/skynet-js/pull/277/checks?check_run_id=1768989935