### PR TITLE
Change default getEntry timeout to 2s

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { SkynetClient } from "./client";
 export { deriveChildSeed, genKeyPairAndSeed, genKeyPairFromSeed } from "./crypto";
+export { DEFAULT_GET_ENTRY_TIMEOUT, MAX_GET_ENTRY_TIMEOUT } from "./registry";
 export {
   MAX_REVISION,
   defaultPortalUrl,

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { genKeyPairAndSeed } from "./crypto";
-import { SkynetClient, defaultSkynetPortalUrl, genKeyPairFromSeed } from "./index";
-import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
+import { SkynetClient, defaultSkynetPortalUrl, genKeyPairFromSeed, DEFAULT_GET_ENTRY_TIMEOUT, MAX_GET_ENTRY_TIMEOUT } from "./index";
 
 const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const portalUrl = defaultSkynetPortalUrl;
@@ -82,7 +81,7 @@ describe("getEntryUrl", () => {
   it("should generate the correct registry url for the given entry", () => {
     const url = client.registry.getEntryUrl(publicKey, dataKey);
 
-    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=5`);
+    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`);
   });
 
   it("Should throw if the timeout is not an integer", () => {
@@ -96,7 +95,7 @@ describe("getEntryUrl", () => {
   it("should trim the prefix if it is provided", () => {
     const url = client.registry.getEntryUrl(`ed25519:${publicKey}`, dataKey);
 
-    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=5`);
+    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`);
   });
 });
 

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { genKeyPairAndSeed } from "./crypto";
-import { SkynetClient, defaultSkynetPortalUrl, genKeyPairFromSeed, DEFAULT_GET_ENTRY_TIMEOUT, MAX_GET_ENTRY_TIMEOUT } from "./index";
+import {
+  SkynetClient,
+  defaultSkynetPortalUrl,
+  genKeyPairFromSeed,
+  DEFAULT_GET_ENTRY_TIMEOUT,
+  MAX_GET_ENTRY_TIMEOUT,
+} from "./index";
 
 const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const portalUrl = defaultSkynetPortalUrl;
@@ -81,7 +87,9 @@ describe("getEntryUrl", () => {
   it("should generate the correct registry url for the given entry", () => {
     const url = client.registry.getEntryUrl(publicKey, dataKey);
 
-    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`);
+    expect(url).toEqual(
+      `${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`
+    );
   });
 
   it("Should throw if the timeout is not an integer", () => {
@@ -95,7 +103,9 @@ describe("getEntryUrl", () => {
   it("should trim the prefix if it is provided", () => {
     const url = client.registry.getEntryUrl(`ed25519:${publicKey}`, dataKey);
 
-    expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`);
+    expect(url).toEqual(
+      `${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=${DEFAULT_GET_ENTRY_TIMEOUT}`
+    );
   });
 });
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -19,7 +19,7 @@ import { hashDataKey, hashRegistryEntry, Signature } from "./crypto";
 /**
  * Custom get entry options.
  *
- * @property [timeout=5] - The custom timeout for getting an entry, in seconds. The maximum value allowed is 300.
+ * @property [timeout=2] - The custom timeout for getting an entry, in seconds. The maximum value allowed is 300.
  */
 export type CustomGetEntryOptions = BaseCustomOptions & {
   timeout?: number;
@@ -32,7 +32,7 @@ export type CustomSetEntryOptions = BaseCustomOptions;
 
 const defaultGetEntryOptions = {
   ...defaultOptions("/skynet/registry"),
-  timeout: 5,
+  timeout: 2,
 };
 
 const defaultSetEntryOptions = {

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -16,6 +16,20 @@ import {
 } from "./utils";
 import { hashDataKey, hashRegistryEntry, Signature } from "./crypto";
 
+export const DEFAULT_GET_ENTRY_TIMEOUT = 2;
+
+export const MAX_GET_ENTRY_TIMEOUT = 300; // 5 minutes
+
+/**
+ * Regex for JSON revision value without quotes.
+ */
+export const regexRevisionNoQuotes = /"revision":\s*([0-9]+)/;
+
+/**
+ * Regex for JSON revision value with quotes.
+ */
+const regexRevisionWithQuotes = /"revision":\s*"([0-9]+)"/;
+
 /**
  * Custom get entry options.
  *
@@ -32,24 +46,12 @@ export type CustomSetEntryOptions = BaseCustomOptions;
 
 const defaultGetEntryOptions = {
   ...defaultOptions("/skynet/registry"),
-  timeout: 2,
+  timeout: DEFAULT_GET_ENTRY_TIMEOUT,
 };
 
 const defaultSetEntryOptions = {
   ...defaultOptions("/skynet/registry"),
 };
-
-export const MAX_GET_ENTRY_TIMEOUT = 300; // 5 minutes
-
-/**
- * Regex for JSON revision value without quotes.
- */
-export const regexRevisionNoQuotes = /"revision":\s*([0-9]+)/;
-
-/**
- * Regex for JSON revision value with quotes.
- */
-const regexRevisionWithQuotes = /"revision":\s*"([0-9]+)"/;
 
 /**
  * Registry entry.


### PR DESCRIPTION
This is a perflormance fix that will make the perceived performance of many applications snappier by default.

The vast majority of registry reads are under 1 s:
https://discord.com/channels/542938080349519882/799542652143403019/803837030903054347
so if a read takes longer than 2 s it is safe to say it will fail.

Specific applications can set the timeout even lower, 1.5 s should be a safe value.