### PR TITLE
Update version to 3.0.2

### DIFF
--- a/CHANGELOG-BETA.md
+++ b/CHANGELOG-BETA.md
@@ -1,0 +1,48 @@
+# Changelog (Beta)
+
+_Beta versions are released on the `beta` stream. The latest beta can be installed with `npm install skynet-js@beta`._
+
+For the latest stable changes, see [CHANGELOG.md](./CHANGELOG.md).
+
+## [3.0.2-beta]
+
+### Added
+
+- Add portalUrl response field to `getFileContents` and `getMetadata`.
+
+### Changed
+
+- Fix a bug where registry entries with empty data were rejected.
+- The bundle size when building with webpack has been further reduced.
+
+## [3.0.1-beta]
+
+### Changed
+
+- A new optimization causes `db.setJSON` to complete significantly faster.
+- The size of the bundled SDK has been reduced by more than 60% by changing crypto dependencies.
+
+## [3.0.0-beta]
+
+[Updating Guide](https://siasky.net/docs/v3-beta/#updating-from-v2)
+
+_This beta version is released on the `beta` stream. It can be installed with `npm install skynet-js@beta`._
+
+### Added
+
+- `getFileContent` and `getFileContentHns` methods have been added for getting the content of a file from a skylink or Handshake domain without downloading the file in-browser.
+
+### Changed
+
+- **[Breaking change]** Entry revisions are now `bigint` instead of `number`.
+- **[Breaking change]** Upload methods return full objects instead of just a skylink string.
+- **[Breaking change]** Upload request methods were removed.
+- **[Breaking change]** `getMetadata` returns a full object containing the metadata in a subfield.
+- **[Breaking change]** The registry timeout has changed to take seconds instead of milliseconds.
+- **[Breaking change]** `db.getJSON` can return destructured nulls instead of null
+- **[Breaking change]** `registry.getEntry` only returns `null` on entry-not-found.
+- Almost every API method now has the potential to throw. A common cause would be wrongly-typed inputs to a method, which are now checked.
+
+### Removed
+
+- **[Breaking change]** `executeRequest` was removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 For the latest beta changes, see [CHANGELOG-BETA.md](./CHANGELOG-BETA.md).
 
+## [3.0.2]
+
+### Added
+
+- Add portalUrl response field to `getFileContents` and `getMetadata`.
+
+### Changed
+
+- A new optimization causes `db.setJSON` to complete significantly faster.
+- The size of the bundled SDK has been reduced by more than 60% by changing crypto dependencies.
+- Fix a bug where registry entries with empty data were rejected.
+
 ## [3.0.0]
 
 [Updating Guide](https://siasky.net/docs/v3/#updating-from-v2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
 # Changelog
 
-## [3.0.1-beta]
-
-_This beta version is released on the `beta` stream. It can be installed with `npm install skynet-js@beta`._
-
-### Changed
-
-- A new optimization causes `db.setJSON` to complete significantly faster.
-- The size of the bundled SDK has been reduced by more than 60% by changing crypto dependencies.
+For the latest beta changes, see [CHANGELOG-BETA.md](./CHANGELOG-BETA.md).
 
 ## [3.0.0]
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ We have some automated checks that must pass in order for code to be accepted. T
 - 100% code coverage is enforced. Every statement and conditional branch must be tested.
 
 Note that the 100% coverage requirement is a _minimum_. Just because a line of code is tested does not mean it is tested _well_, that is, with different values and combinations of values. Tests should be as thorough as possible, within reason.
+
+## Changelogs
+
+- [Stable](./CHANGELOG.md)
+- [Beta](./CHANGELOG-BETA.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skynet-js",
-  "version": "3.0.2-beta",
+  "version": "3.0.2",
   "description": "Sia Skynet Javascript Client",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skynet-js",
-  "version": "3.0.1-beta",
+  "version": "3.0.2-beta",
   "description": "Sia Skynet Javascript Client",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
I want to release a new version with an addition which is needed for `skybin`. Also, it's been a while since we released a new stable version and there have been some useful fixes.

**Note:** We skip version 3.0.1 because we never published a corresponding stable version for 3.0.1-beta and there has been a new beta release since then.