### PR TITLE
[BREAKING] Add async portal url init, get*UrlForPortal functions

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { SkynetClient } from "./index";
+import { defaultSkynetPortalUrl } from "./utils/url";
+
+const portalUrl = defaultSkynetPortalUrl;
+let client: SkynetClient;
+let mock: MockAdapter;
+
+describe("new SkynetClient", () => {
+  it("should fail to initialize if portal URL header is not found", async () => {
+    mock = new MockAdapter(axios);
+    mock.onHead(portalUrl).replyOnce(200, {}, {});
+    client = new SkynetClient(portalUrl);
+
+    await expect(client.portalUrl).rejects.toThrowError("Could not get portal URL for the given portal");
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -120,12 +120,17 @@ export class SkynetClient {
       url: initialPortalUrl,
       endpointPath: "/",
     }).then((response) => {
+      /* istanbul ignore next */
       if (typeof response.headers === "undefined") {
         throw new Error(
           "Did not get 'headers' in response despite a successful request. Please try again and report this issue to the devs if it persists."
         );
       }
-      return response.headers["skynet-portal-api"] ?? "";
+      const portalUrl = response.headers["skynet-portal-api"];
+      if (!portalUrl) {
+        throw new Error("Could not get portal URL for the given portal");
+      }
+      return portalUrl;
     });
 
     this.customOptions = customOptions;

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,15 +1,13 @@
 import { SkynetClient } from "./client";
 import {
   BaseCustomOptions,
-  convertSkylinkToBase32,
   defaultOptions,
   formatSkylink,
-  parseSkylink,
   uriHandshakePrefix,
   uriHandshakeResolverPrefix,
 } from "./utils/skylink";
 import { trimUriPrefix } from "./utils/string";
-import { addSubdomain, addUrlQuery, makeUrl } from "./utils/url";
+import { addSubdomain, addUrlQuery, getSkylinkUrlForPortal, makeUrl } from "./utils/url";
 
 /**
  * Custom download options.
@@ -78,7 +76,7 @@ export type ResolveHnsResponse = {
   skylink: string;
 };
 
-const defaultDownloadOptions = {
+export const defaultDownloadOptions = {
   ...defaultOptions("/"),
 };
 const defaultDownloadHnsOptions = {
@@ -99,14 +97,18 @@ const defaultResolveHnsOptions = {
  * @returns - The full URL that was used.
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
-export function downloadFile(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
+export async function downloadFile(
+  this: SkynetClient,
+  skylinkUrl: string,
+  customOptions?: CustomDownloadOptions
+): Promise<string> {
   /* istanbul ignore next */
   if (typeof skylinkUrl !== "string") {
     throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
   }
 
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions, download: true };
-  const url = this.getSkylinkUrl(skylinkUrl, opts);
+  const url = await this.getSkylinkUrl(skylinkUrl, opts);
 
   // Download the url.
   window.location.assign(url);
@@ -135,7 +137,7 @@ export async function downloadFileHns(
   }
 
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions, download: true };
-  const url = this.getHnsUrl(domain, opts);
+  const url = await this.getHnsUrl(domain, opts);
 
   // Download the url.
   window.location.assign(url);
@@ -153,64 +155,16 @@ export async function downloadFileHns(
  * @returns - The full URL for the skylink.
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
-export function getSkylinkUrl(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
-  /* istanbul ignore next */
-  if (typeof skylinkUrl !== "string") {
-    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
-  }
-
+export async function getSkylinkUrl(
+  this: SkynetClient,
+  skylinkUrl: string,
+  customOptions?: CustomDownloadOptions
+): Promise<string> {
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
-  const query = opts.query ?? {};
-  if (opts.download) {
-    // Set the "attachment" parameter.
-    query.attachment = true;
-  }
-  if (opts.noResponseMetadata) {
-    // Set the "no-response-metadata" parameter.
-    query["no-response-metadata"] = true;
-  }
 
-  // URL-encode the path.
-  let path = "";
-  if (opts.path) {
-    if (typeof opts.path !== "string") {
-      throw new Error(`opts.path has to be a string, ${typeof opts.path} provided`);
-    }
+  const portalUrl = await this.portalUrl;
 
-    // Encode each element of the path separately and join them.
-    //
-    // Don't use encodeURI because it does not encode characters such as '?'
-    // etc. These are allowed as filenames on Skynet and should be encoded so
-    // they are not treated as URL separators.
-    path = opts.path
-      .split("/")
-      .map((element: string) => encodeURIComponent(element))
-      .join("/");
-  }
-
-  let url;
-  if (opts.subdomain) {
-    // Get the path from the skylink. Use the empty string if not found.
-    const skylinkPath = parseSkylink(skylinkUrl, { onlyPath: true }) ?? "";
-    // Get just the skylink.
-    let skylink = parseSkylink(skylinkUrl);
-    if (skylink === null) {
-      throw new Error(`Could not get skylink out of input '${skylinkUrl}'`);
-    }
-    // Convert the skylink (without the path) to base32.
-    skylink = convertSkylinkToBase32(skylink);
-    url = addSubdomain(this.portalUrl, skylink);
-    url = makeUrl(url, skylinkPath, path);
-  } else {
-    // Get the skylink including the path.
-    const skylink = parseSkylink(skylinkUrl, { includePath: true });
-    if (skylink === null) {
-      throw new Error(`Could not get skylink with path out of input '${skylinkUrl}'`);
-    }
-    // Add additional path if passed in.
-    url = makeUrl(this.portalUrl, opts.endpointPath, skylink, path);
-  }
-  return addUrlQuery(url, query);
+  return getSkylinkUrlForPortal(portalUrl, skylinkUrl, opts);
 }
 
 /**
@@ -223,7 +177,11 @@ export function getSkylinkUrl(this: SkynetClient, skylinkUrl: string, customOpti
  * @returns - The full URL for the HNS domain.
  * @throws - Will throw if the input domain is not a string.
  */
-export function getHnsUrl(this: SkynetClient, domain: string, customOptions?: CustomHnsDownloadOptions): string {
+export async function getHnsUrl(
+  this: SkynetClient,
+  domain: string,
+  customOptions?: CustomHnsDownloadOptions
+): Promise<string> {
   /* istanbul ignore next */
   if (typeof domain !== "string") {
     throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
@@ -239,9 +197,10 @@ export function getHnsUrl(this: SkynetClient, domain: string, customOptions?: Cu
   }
 
   domain = trimUriPrefix(domain, uriHandshakePrefix);
+  const portalUrl = await this.portalUrl;
   const url = opts.subdomain
-    ? addSubdomain(addSubdomain(this.portalUrl, opts.hnsSubdomain), domain)
-    : makeUrl(this.portalUrl, opts.endpointPath, domain);
+    ? addSubdomain(addSubdomain(portalUrl, opts.hnsSubdomain), domain)
+    : makeUrl(portalUrl, opts.endpointPath, domain);
   return addUrlQuery(url, query);
 }
 
@@ -255,7 +214,11 @@ export function getHnsUrl(this: SkynetClient, domain: string, customOptions?: Cu
  * @returns - The full URL for the resolver for the HNS domain.
  * @throws - Will throw if the input domain is not a string.
  */
-export function getHnsresUrl(this: SkynetClient, domain: string, customOptions?: BaseCustomOptions): string {
+export async function getHnsresUrl(
+  this: SkynetClient,
+  domain: string,
+  customOptions?: BaseCustomOptions
+): Promise<string> {
   /* istanbul ignore next */
   if (typeof domain !== "string") {
     throw new Error(`Expected parameter domain to be type string, was type ${typeof domain}`);
@@ -264,7 +227,8 @@ export function getHnsresUrl(this: SkynetClient, domain: string, customOptions?:
   const opts = { ...defaultResolveHnsOptions, ...this.customOptions, ...customOptions };
 
   domain = trimUriPrefix(domain, uriHandshakeResolverPrefix);
-  return makeUrl(this.portalUrl, opts.endpointPath, domain);
+  const portalUrl = await this.portalUrl;
+  return makeUrl(portalUrl, opts.endpointPath, domain);
 }
 
 /**
@@ -288,7 +252,7 @@ export async function getMetadata(
   }
 
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
-  const url = this.getSkylinkUrl(skylinkUrl, opts);
+  const url = await this.getSkylinkUrl(skylinkUrl, opts);
 
   const response = await this.executeRequest({
     ...opts,
@@ -331,7 +295,7 @@ export async function getFileContent<T = unknown>(
   }
 
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
-  const url = this.getSkylinkUrl(skylinkUrl, opts);
+  const url = await this.getSkylinkUrl(skylinkUrl, opts);
 
   return this.getFileContentRequest<T>(url, opts);
 }
@@ -352,7 +316,7 @@ export async function getFileContentHns<T = unknown>(
   customOptions?: CustomHnsDownloadOptions
 ): Promise<GetFileContentResponse<T>> {
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions };
-  const url = this.getHnsUrl(domain, opts);
+  const url = await this.getHnsUrl(domain, opts);
 
   return this.getFileContentRequest<T>(url, opts);
 }
@@ -409,14 +373,18 @@ export async function getFileContentRequest<T = unknown>(
  * @returns - The full URL that was used.
  * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
  */
-export function openFile(this: SkynetClient, skylinkUrl: string, customOptions?: CustomDownloadOptions): string {
+export async function openFile(
+  this: SkynetClient,
+  skylinkUrl: string,
+  customOptions?: CustomDownloadOptions
+): Promise<string> {
   /* istanbul ignore next */
   if (typeof skylinkUrl !== "string") {
     throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
   }
 
   const opts = { ...defaultDownloadOptions, ...this.customOptions, ...customOptions };
-  const url = this.getSkylinkUrl(skylinkUrl, opts);
+  const url = await this.getSkylinkUrl(skylinkUrl, opts);
 
   window.open(url, "_blank");
 
@@ -444,7 +412,7 @@ export async function openFileHns(
   }
 
   const opts = { ...defaultDownloadHnsOptions, ...this.customOptions, ...customOptions };
-  const url = this.getHnsUrl(domain, opts);
+  const url = await this.getHnsUrl(domain, opts);
 
   // Open the url in a new tab.
   window.open(url, "_blank");
@@ -473,7 +441,7 @@ export async function resolveHns(
   }
 
   const opts = { ...defaultResolveHnsOptions, ...this.customOptions, ...customOptions };
-  const url = this.getHnsresUrl(domain, opts);
+  const url = await this.getHnsresUrl(domain, opts);
 
   // Get the txt record from the hnsres domain on the portal.
   const response = await this.executeRequest({

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { deriveChildSeed, genKeyPairAndSeed, genKeyPairFromSeed } from "./crypto
 export { getRelativeFilePath, getRootDirectory } from "./utils/file";
 export { MAX_REVISION } from "./utils/number";
 export { parseSkylink, uriHandshakePrefix, uriHandshakeResolverPrefix, uriSkynetPrefix } from "./utils/skylink";
-export { defaultPortalUrl, defaultSkynetPortalUrl } from "./utils/url";
+export { defaultPortalUrl, defaultSkynetPortalUrl, getEntryUrlForPortal, getSkylinkUrlForPortal } from "./utils/url";
 
 // Export types.
 

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -3,13 +3,14 @@ import MockAdapter from "axios-mock-adapter";
 import { genKeyPairAndSeed } from "./crypto";
 import { SkynetClient, defaultSkynetPortalUrl, genKeyPairFromSeed } from "./index";
 import { MAX_GET_ENTRY_TIMEOUT } from "./registry";
+import { getEntryUrlForPortal } from "./utils/url";
 
 const { publicKey, privateKey } = genKeyPairFromSeed("insecure test seed");
 const portalUrl = defaultSkynetPortalUrl;
 const client = new SkynetClient(portalUrl);
 const dataKey = "app";
 
-const registryLookupUrl = client.registry.getEntryUrl(publicKey, dataKey);
+const registryLookupUrl = getEntryUrlForPortal(portalUrl, publicKey, dataKey);
 
 describe("getEntry", () => {
   let mock: MockAdapter;
@@ -79,22 +80,22 @@ describe("getEntryUrl", () => {
   const encodedPK = "ed25519%3Ac1197e1275fbf570d21dde01a00af83ed4a743d1884e4a09cebce0dd21ae254c";
   const encodedDK = "7c96a0537ab2aaac9cfe0eca217732f4e10791625b4ab4c17e4d91c8078713b9";
 
-  it("should generate the correct registry url for the given entry", () => {
-    const url = client.registry.getEntryUrl(publicKey, dataKey);
+  it("should generate the correct registry url for the given entry", async () => {
+    const url = await client.registry.getEntryUrl(publicKey, dataKey);
 
     expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=5`);
   });
 
-  it("Should throw if the timeout is not an integer", () => {
+  it("Should throw if the timeout is not an integer", async () => {
     const { publicKey } = genKeyPairAndSeed();
 
-    expect(() => client.registry.getEntryUrl(publicKey, dataKey, { timeout: 1.5 })).toThrowError(
+    await expect(client.registry.getEntryUrl(publicKey, dataKey, { timeout: 1.5 })).rejects.toThrowError(
       "Invalid 'timeout' parameter '1.5', needs to be an integer between 1s and 300s"
     );
   });
 
-  it("should trim the prefix if it is provided", () => {
-    const url = client.registry.getEntryUrl(`ed25519:${publicKey}`, dataKey);
+  it("should trim the prefix if it is provided", async () => {
+    const url = await client.registry.getEntryUrl(`ed25519:${publicKey}`, dataKey);
 
     expect(url).toEqual(`${portalUrl}/skynet/registry?publickey=${encodedPK}&datakey=${encodedDK}&timeout=5`);
   });

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -11,6 +11,7 @@ const sialink = `${uriSkynetPrefix}${skylink}`;
 const merkleroot = "QAf9Q7dBSbMarLvyeE6HTQmwhr7RX9VMrP9xIMzpU3I";
 const bitfield = 2048;
 const data = { skylink, merkleroot, bitfield };
+let mock: MockAdapter;
 
 describe("uploadFile", () => {
   const url = `${portalUrl}/skynet/skyfile`;
@@ -18,7 +19,6 @@ describe("uploadFile", () => {
   const file = new File(["foo"], filename, {
     type: "text/plain",
   });
-  let mock: MockAdapter;
 
   beforeEach(() => {
     mock = new MockAdapter(axios);
@@ -155,7 +155,6 @@ describe("uploadDirectory", () => {
     "i-am-not/me-neither/file3.jpeg": new File(["foo3"], "i-am-not/me-neither/file3.jpeg"),
   };
   const url = `${portalUrl}/skynet/skyfile?filename=${filename}`;
-  let mock: MockAdapter;
 
   beforeEach(() => {
     mock = new MockAdapter(axios);

--- a/src/upload.test.ts
+++ b/src/upload.test.ts
@@ -23,6 +23,7 @@ describe("uploadFile", () => {
   beforeEach(() => {
     mock = new MockAdapter(axios);
     mock.onPost(url).replyOnce(200, data);
+    mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
     mock.resetHistory();
   });
 
@@ -37,10 +38,11 @@ describe("uploadFile", () => {
     expect(data.skylink).toEqual(sialink);
   });
 
-  it("should send register onUploadProgress callback if defined", async () => {
+  it("should register onUploadProgress callback if defined", async () => {
     const newPortal = "https://my-portal.net";
     const url = `${newPortal}/skynet/skyfile`;
     const client = new SkynetClient(newPortal);
+    mock.onHead(newPortal).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
 
     // Use replyOnce to catch a single request with the new URL.
     mock.onPost(url).replyOnce(200, data);
@@ -117,6 +119,7 @@ describe("uploadFile", () => {
     const portalUrl = "https://portal.net";
     const url = `${portalUrl}/skynet/skyfile`;
     const client = new SkynetClient(portalUrl, { customUserAgent: "Sia-Agent" });
+    mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
 
     mock.onPost(`${url}?file=test`).replyOnce(200, data);
 
@@ -157,6 +160,7 @@ describe("uploadDirectory", () => {
   beforeEach(() => {
     mock = new MockAdapter(axios);
     mock.onPost(url).replyOnce(200, data);
+    mock.onHead(portalUrl).replyOnce(200, {}, { "skynet-portal-api": portalUrl });
     mock.resetHistory();
   });
 

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,11 @@
 import parse from "url-parse";
 import urljoin from "url-join";
-import { trimSuffix } from "./string";
+
+import { isHexString, toHexString, trimPrefix, trimSuffix } from "./string";
+import { defaultGetEntryOptions, CustomGetEntryOptions, MAX_GET_ENTRY_TIMEOUT } from "../registry";
+import { hashDataKey } from "../crypto";
+import { defaultDownloadOptions, CustomDownloadOptions } from "../download";
+import { convertSkylinkToBase32, parseSkylink } from "./skylink";
 
 export const defaultSkynetPortalUrl = "https://siasky.net";
 
@@ -55,4 +60,142 @@ export function addUrlQuery(url: string, query: Record<string, unknown>): string
  */
 export function makeUrl(...args: string[]): string {
   return args.reduce((acc, cur) => urljoin(acc, cur));
+}
+
+/**
+ * Gets the registry entry URL without an initialized client.
+ *
+ * @param portalUrl - The portal URL.
+ * @param publicKey - The user public key.
+ * @param dataKey - The key of the data to fetch for the given user.
+ * @param [customOptions] - Additional settings that can optionally be set.
+ * @returns - The full get entry URL.
+ * @throws - Will throw if the provided timeout is invalid or the given key is not valid.
+ */
+export function getEntryUrlForPortal(
+  portalUrl: string,
+  publicKey: string,
+  dataKey: string,
+  customOptions?: CustomGetEntryOptions
+): string {
+  /* istanbul ignore next */
+  if (typeof portalUrl !== "string") {
+    throw new Error(`Expected parameter 'portalUrl' to be type string, was type ${typeof portalUrl}`);
+  }
+  /* istanbul ignore next */
+  if (typeof publicKey !== "string") {
+    throw new Error(`Expected parameter 'publicKey' to be type string, was type ${typeof publicKey}`);
+  }
+  /* istanbul ignore next */
+  if (typeof dataKey !== "string") {
+    throw new Error(`Expected parameter 'dataKey' to be type string, was type ${typeof dataKey}`);
+  }
+
+  const opts = {
+    ...defaultGetEntryOptions,
+    ...customOptions,
+  };
+
+  const timeout = opts.timeout;
+
+  if (!Number.isInteger(timeout) || timeout > MAX_GET_ENTRY_TIMEOUT || timeout < 1) {
+    throw new Error(
+      `Invalid 'timeout' parameter '${timeout}', needs to be an integer between 1s and ${MAX_GET_ENTRY_TIMEOUT}s`
+    );
+  }
+
+  // Trim the prefix if it was passed in.
+  publicKey = trimPrefix(publicKey, "ed25519:");
+  if (!isHexString(publicKey)) {
+    throw new Error(`Given public key '${publicKey}' is not a valid hex-encoded string or contains an invalid prefix`);
+  }
+
+  const query = {
+    publickey: `ed25519:${publicKey}`,
+    datakey: toHexString(hashDataKey(dataKey)),
+    timeout,
+  };
+
+  let url = makeUrl(portalUrl, opts.endpointPath);
+  url = addUrlQuery(url, query);
+
+  return url;
+}
+
+/**
+ * Gets the skylink URL without an initialized client.
+ *
+ * @param portalUrl - The portal URL.
+ * @param skylinkUrl - Skylink string. See `downloadFile`.
+ * @param [customOptions] - Additional settings that can optionally be set.
+ * @returns - The full URL for the skylink.
+ * @throws - Will throw if the skylinkUrl does not contain a skylink or if the path option is not a string.
+ */
+export function getSkylinkUrlForPortal(
+  portalUrl: string,
+  skylinkUrl: string,
+  customOptions?: CustomDownloadOptions
+): string {
+  /* istanbul ignore next */
+  if (typeof portalUrl !== "string") {
+    throw new Error(`Expected parameter 'portalUrl' to be type string, was type ${typeof portalUrl}`);
+  }
+  /* istanbul ignore next */
+  if (typeof skylinkUrl !== "string") {
+    throw new Error(`Expected parameter skylinkUrl to be type string, was type ${typeof skylinkUrl}`);
+  }
+
+  const opts = { ...defaultDownloadOptions, ...customOptions };
+
+  const query = opts.query ?? {};
+  if (opts.download) {
+    // Set the "attachment" parameter.
+    query.attachment = true;
+  }
+  if (opts.noResponseMetadata) {
+    // Set the "no-response-metadata" parameter.
+    query["no-response-metadata"] = true;
+  }
+
+  // URL-encode the path.
+  let path = "";
+  if (opts.path) {
+    if (typeof opts.path !== "string") {
+      throw new Error(`opts.path has to be a string, ${typeof opts.path} provided`);
+    }
+
+    // Encode each element of the path separately and join them.
+    //
+    // Don't use encodeURI because it does not encode characters such as '?'
+    // etc. These are allowed as filenames on Skynet and should be encoded so
+    // they are not treated as URL separators.
+    path = opts.path
+      .split("/")
+      .map((element: string) => encodeURIComponent(element))
+      .join("/");
+  }
+
+  let url;
+  if (opts.subdomain) {
+    // Get the path from the skylink. Use the empty string if not found.
+    const skylinkPath = parseSkylink(skylinkUrl, { onlyPath: true }) ?? "";
+    // Get just the skylink.
+    let skylink = parseSkylink(skylinkUrl);
+    if (skylink === null) {
+      throw new Error(`Could not get skylink out of input '${skylinkUrl}'`);
+    }
+    // Convert the skylink (without the path) to base32.
+    skylink = convertSkylinkToBase32(skylink);
+    url = addSubdomain(portalUrl, skylink);
+    url = makeUrl(url, skylinkPath, path);
+  } else {
+    // Get the skylink including the path.
+    const skylink = parseSkylink(skylinkUrl, { includePath: true });
+    if (skylink === null) {
+      throw new Error(`Could not get skylink with path out of input '${skylinkUrl}'`);
+    }
+    // Add additional path if passed in.
+    url = makeUrl(portalUrl, opts.endpointPath, skylink, path);
+  }
+  return addUrlQuery(url, query);
 }


### PR DESCRIPTION
- All client download and `client.get*Url` functions are now `async`.
- Added `getEntryUrlForPortal` standalone method
- Added `getSkylinkUrlForPortal` standalone method

**Note:** To keep the PR lean I didn't address the case of providing a portal URL (e.g. `new SkynetClient("https://siasky.net")`) when we are already on a portal -- that should have no effect, the portal argument should only be for dev testing.